### PR TITLE
perf: request games in 18-item pages

### DIFF
--- a/apps/api/src/shared/providers/igdb/igdb-provider.ts
+++ b/apps/api/src/shared/providers/igdb/igdb-provider.ts
@@ -1,0 +1,2436 @@
+import { envs } from '../../config/envs';
+import { ADMIN_GAME_BANNERS } from '../../constants/admin-banners';
+
+export type IgdbGame = {
+  id: number;
+  name: string;
+  slug: string;
+  summary?: string;
+  storyline?: string;
+  coverUrl?: string;
+  bannerUrl?: string;
+  artworks?: string[];
+  screenshots?: string[];
+  genres: string[];
+  platforms: string[];
+  gameModes?: string[];
+  firstReleaseDate?: string;
+  releaseYear?: string;
+  developer?: string;
+  publisher?: string;
+  rating?: number;
+  aggregatedRating?: number;
+  category?: number;
+  genreIds?: number[];
+  similarGames?: IgdbGame[];
+  recommendedGames?: IgdbGame[];
+};
+
+type IgdbRawGame = {
+  id: number;
+  name: string;
+  slug: string;
+  category?: number;
+  summary?: string;
+  storyline?: string;
+  cover?: { id: number; image_id?: string; url?: string };
+  artworks?: { id: number; image_id?: string; url?: string }[];
+  screenshots?: { id: number; image_id?: string; url?: string }[];
+  genres?: { id: number; name: string }[];
+  platforms?: { id: number; name: string; abbreviation?: string }[];
+  game_modes?: { id: number; name: string }[];
+  first_release_date?: number;
+  rating?: number;
+  aggregated_rating?: number;
+  involved_companies?: {
+    id: number;
+    developer: boolean;
+    publisher: boolean;
+    company?: { id: number; name: string };
+  }[];
+  similar_games?: (IgdbRawGame | number)[];
+};
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function removeSearchFillers(value: string): string {
+  const fillerWords = new Set([
+    'a',
+    'an',
+    'and',
+    'da',
+    'das',
+    'de',
+    'do',
+    'dos',
+    'e',
+    'for',
+    'in',
+    'of',
+    'on',
+    'the',
+    'to'
+  ]);
+  return value
+    .split(' ')
+    .filter((word) => word && !fillerWords.has(word))
+    .join(' ');
+}
+
+function getSearchRelevance(game: Pick<IgdbGame, 'name' | 'slug'>, query: string): number {
+  const normalizedQuery = normalizeSearchText(query);
+  const normalizedName = normalizeSearchText(game.name);
+  const normalizedSlug = normalizeSearchText(game.slug);
+  const compactQuery = removeSearchFillers(normalizedQuery);
+  const compactName = removeSearchFillers(normalizedName);
+
+  if (!normalizedQuery) return 0;
+  if (normalizedName === normalizedQuery || normalizedSlug === normalizedQuery) return 100;
+  if (compactName === compactQuery) return 95;
+  if (normalizedName.startsWith(normalizedQuery)) return 90;
+  if (normalizedName.split(' ').some((word) => word.startsWith(normalizedQuery))) return 80;
+  if (normalizedName.includes(normalizedQuery) || normalizedSlug.includes(normalizedQuery))
+    return 70;
+
+  if (compactQuery.length > 1 && compactName.startsWith(compactQuery)) return 85;
+
+  return 0;
+}
+
+class IgdbProvider {
+  private clientId: string | undefined;
+  private clientSecret: string | undefined;
+  private accessToken: string | null = null;
+  private tokenExpiresAt: number = 0;
+  private mediaCache = new Map<
+    string,
+    {
+      coverUrl?: string;
+      bannerUrl?: string;
+      slug?: string;
+      genres?: string[];
+      platforms?: string[];
+    }
+  >();
+  private gameDetailsCache = new Map<string, { data: IgdbGame; timestamp: number }>();
+  private recommendedCache = new Map<string, { data: IgdbGame[]; timestamp: number }>();
+
+  constructor() {
+    this.clientId = envs.services.TWITCH_CLIENT_ID;
+    this.clientSecret = envs.services.TWITCH_CLIENT_SECRET;
+  }
+
+  isDlcOrExpansion(name?: string | null, slug?: string | null, category?: number): boolean {
+    // IGDB Categories:
+    // 0 = Main Game, 8 = Remake, 9 = Remaster.
+    // 1 = DLC / Add-on, 2 = Expansion, 3 = Bundle, 4 = Standalone Expansion, 5 = Mod, 6 = Episode, 7 = Season, 10 = Expanded Game, 13 = Pack, 14 = Update.
+    if (typeof category === 'number' && category !== 0 && category !== 8 && category !== 9) {
+      return true;
+    }
+
+    const n = (name || '').toLowerCase();
+    const s = (slug || '').toLowerCase();
+
+    const forbiddenPatterns = [
+      'game of the year',
+      'goty',
+      'expansion',
+      'dlc',
+      'season pass',
+      'expansion pass',
+      'deluxe edition',
+      'complete edition',
+      'ultimate edition',
+      'gold edition',
+      'silver edition',
+      "collector's edition",
+      'collectors edition',
+      'special edition',
+      'definitive edition',
+      'anniversary edition',
+      'enhanced edition',
+      'soundtrack',
+      'artbook',
+      'booster pack',
+      'skin pack',
+      'character pack',
+      'dlc pack',
+      'upgrade pack',
+      'bonus content',
+      'add-on',
+      'starter pack',
+      'founders pack',
+      'battle pass',
+      'bundle',
+      'digital soundtrack',
+      'original soundtrack',
+      'shadow of the erdtree'
+    ];
+
+    return forbiddenPatterns.some((pattern) => n.includes(pattern) || s.includes(pattern));
+  }
+
+  private async getAccessToken(): Promise<string | null> {
+    if (!this.clientId || !this.clientSecret) {
+      return null;
+    }
+
+    const now = Date.now();
+    if (this.accessToken && this.tokenExpiresAt > now + 60000) {
+      return this.accessToken;
+    }
+
+    try {
+      const res = await fetch(
+        `https://id.twitch.tv/oauth2/token?client_id=${this.clientId}&client_secret=${this.clientSecret}&grant_type=client_credentials`,
+        { method: 'POST' }
+      );
+
+      if (!res.ok) {
+        console.error('Failed to get Twitch access token for IGDB:', await res.text());
+        return null;
+      }
+
+      const data = (await res.json()) as { access_token: string; expires_in: number };
+      this.accessToken = data.access_token;
+      this.tokenExpiresAt = now + data.expires_in * 1000;
+      return this.accessToken;
+    } catch (err) {
+      console.error('Error fetching Twitch token for IGDB:', err);
+      return null;
+    }
+  }
+
+  private formatImageUrl(
+    imageId?: string,
+    size: 't_cover_big' | 't_1080p' | 't_720p' | 't_screenshot_huge' = 't_cover_big'
+  ): string | undefined {
+    if (!imageId) return undefined;
+    return `https://images.igdb.com/igdb/image/upload/${size}/${imageId}.webp`;
+  }
+
+  private transformGame(raw: IgdbRawGame): IgdbGame {
+    const coverUrl = raw.cover?.image_id
+      ? this.formatImageUrl(raw.cover.image_id, 't_cover_big')
+      : raw.cover?.url?.replace('t_thumb', 't_cover_big')?.replace(/^\/\//, 'https://');
+
+    const slug = raw.slug || raw.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const adminBanner = ADMIN_GAME_BANNERS[slug] || ADMIN_GAME_BANNERS[String(raw.id)];
+
+    // Pick admin banner, top artwork, or screenshot for 1080p banner (avoid vertical coverUrl which causes blurry stretch)
+    const topArtwork = raw.artworks?.[0]?.image_id || raw.screenshots?.[0]?.image_id;
+    const bannerUrl =
+      adminBanner || (topArtwork ? this.formatImageUrl(topArtwork, 't_1080p') : undefined);
+
+    const artworks =
+      (raw.artworks
+        ?.map((a) => this.formatImageUrl(a.image_id, 't_1080p'))
+        .filter(Boolean) as string[]) || [];
+
+    const screenshots =
+      (raw.screenshots
+        ?.map((s) => this.formatImageUrl(s.image_id, 't_1080p'))
+        .filter(Boolean) as string[]) || [];
+
+    const genres = raw.genres?.map((g) => g.name) || [];
+    const genreIds = raw.genres?.map((g) => g.id) || [];
+    const platforms = raw.platforms?.map((p) => p.name) || [];
+    const gameModes = raw.game_modes?.map((mode) => mode.name) || [];
+
+    let releaseYear: string | undefined;
+    let firstReleaseDate: string | undefined;
+    if (raw.first_release_date) {
+      const d = new Date(raw.first_release_date * 1000);
+      releaseYear = d.getFullYear().toString();
+      firstReleaseDate = d.toISOString();
+    }
+
+    const developer = raw.involved_companies?.find((c) => c.developer)?.company?.name;
+    const publisher = raw.involved_companies?.find((c) => c.publisher)?.company?.name;
+
+    const similarGames: IgdbGame[] | undefined = Array.isArray(raw.similar_games)
+      ? raw.similar_games
+          .filter(
+            (s): s is IgdbRawGame =>
+              typeof s === 'object' &&
+              s !== null &&
+              'name' in s &&
+              !this.isDlcOrExpansion(s.name, s.slug, s.category)
+          )
+          .map((s) => ({
+            id: s.id,
+            name: s.name,
+            slug: s.slug || s.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+            category: s.category,
+            summary: s.summary,
+            coverUrl: s.cover?.image_id
+              ? this.formatImageUrl(s.cover.image_id, 't_cover_big')
+              : s.cover?.url?.replace('t_thumb', 't_cover_big')?.replace(/^\/\//, 'https://'),
+            genres: s.genres?.map((g) => g.name) || [],
+            platforms: s.platforms?.map((p) => p.name) || [],
+            releaseYear: s.first_release_date
+              ? new Date(s.first_release_date * 1000).getFullYear().toString()
+              : undefined,
+            rating: s.rating ? Math.round(s.rating) / 20 : undefined
+          }))
+      : undefined;
+
+    return {
+      id: raw.id,
+      name: raw.name,
+      slug: raw.slug || raw.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      category: raw.category,
+      summary: raw.summary,
+      storyline: raw.storyline,
+      coverUrl,
+      bannerUrl,
+      artworks,
+      screenshots,
+      genres,
+      genreIds,
+      platforms,
+      gameModes,
+      firstReleaseDate,
+      releaseYear,
+      developer,
+      publisher,
+      rating: raw.rating ? Math.round(raw.rating) / 20 : undefined,
+      aggregatedRating: raw.aggregated_rating ? Math.round(raw.aggregated_rating) / 20 : undefined,
+      similarGames
+    };
+  }
+
+  async searchGames(query: string, limit = 20): Promise<IgdbGame[]> {
+    const normalizedQuery = normalizeSearchText(query);
+    if (!normalizedQuery) return [];
+
+    const rankMatches = (games: IgdbGame[]) => {
+      const seenNames = new Set<string>();
+      return games
+        .map((game) => ({ game, relevance: getSearchRelevance(game, normalizedQuery) }))
+        .filter(({ relevance }) => relevance > 0)
+        .sort((a, b) => b.relevance - a.relevance || (b.game.rating || 0) - (a.game.rating || 0))
+        .filter(({ game }) => {
+          const name = normalizeSearchText(game.name);
+          if (seenNames.has(name)) return false;
+          seenNames.add(name);
+          return true;
+        })
+        .slice(0, limit)
+        .map(({ game }) => game);
+    };
+
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) {
+      return rankMatches(this.getFallbackGames());
+    }
+
+    try {
+      const sanitized = query.replace(/"/g, '\\"');
+      const fetchLimit = Math.min(Math.max(limit * 3, 30), 100);
+      const body = `
+        fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+               artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+               genres.id, genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+               first_release_date, rating, aggregated_rating,
+               involved_companies.developer, involved_companies.publisher, involved_companies.company.name;
+        search "${sanitized}";
+        limit ${fetchLimit};
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (!res.ok) {
+        return [];
+      }
+
+      const rawGames = (await res.json()) as IgdbRawGame[];
+      return rankMatches(
+        rawGames
+          .map((g) => this.transformGame(g))
+          .filter((g) => !this.isDlcOrExpansion(g.name, g.slug, g.category))
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Search IGDB by game title to obtain high-quality cover, banner, and IGDB slug.
+   * Uses an in-memory cache to ensure instant lookups on subsequent calls.
+   */
+  async searchGameMediaByTitle(title: string): Promise<{
+    coverUrl?: string;
+    bannerUrl?: string;
+    slug?: string;
+    genres?: string[];
+    platforms?: string[];
+  } | null> {
+    if (!title || !title.trim()) return null;
+    const key = title.trim().toLowerCase();
+    if (this.mediaCache.has(key)) {
+      return this.mediaCache.get(key)!;
+    }
+
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) return null;
+
+    try {
+      // Query variants to handle subtitles, suffixes like ": The Game", etc.
+      const queryVariants = [
+        title,
+        title.replace(/:\s*The Game$/i, '').trim(),
+        title.replace(/\b(The Game|Edition|Remastered|Definitive|VR)\b/gi, '').trim()
+      ].filter((v, i, arr) => arr.indexOf(v) === i && v.length > 0);
+
+      let bestMatch: IgdbRawGame | null = null;
+
+      for (const q of queryVariants) {
+        const clean = q
+          .replace(/[:\-–—]/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        const res = await fetch('https://api.igdb.com/v4/games', {
+          method: 'POST',
+          headers: {
+            'Client-ID': this.clientId,
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'text/plain'
+          },
+          body: `
+            fields name, slug, cover.image_id, artworks.image_id, screenshots.image_id, genres.name, platforms.name, game_modes.name;
+            search "${clean.replace(/"/g, '')}";
+            limit 5;
+          `
+        });
+
+        if (res.ok) {
+          const items = (await res.json()) as IgdbRawGame[];
+          if (Array.isArray(items) && items.length > 0) {
+            const exact = items.find(
+              (it) =>
+                it.name.toLowerCase() === title.toLowerCase() ||
+                it.name.toLowerCase() === q.toLowerCase()
+            );
+            bestMatch = exact || items[0];
+            if (exact) break;
+          }
+        }
+      }
+
+      if (!bestMatch) {
+        return null;
+      }
+
+      const coverUrl = bestMatch.cover?.image_id
+        ? this.formatImageUrl(bestMatch.cover.image_id, 't_cover_big')
+        : undefined;
+
+      const artworkId = bestMatch.artworks?.[0]?.image_id || bestMatch.screenshots?.[0]?.image_id;
+      const bannerUrl = artworkId ? this.formatImageUrl(artworkId, 't_1080p') : undefined;
+
+      const result = {
+        coverUrl,
+        bannerUrl,
+        slug: bestMatch.slug,
+        genres: bestMatch.genres?.map((g: any) => g.name),
+        platforms: bestMatch.platforms?.map((p: any) => p.name)
+      };
+
+      this.mediaCache.set(key, result);
+      return result;
+    } catch (err) {
+      console.warn('[IgdbProvider] Error searching media for:', title, err);
+      return null;
+    }
+  }
+
+  /**
+   * Enriches a list of games (sourced from Steam or other stores) with IGDB images and slugs.
+   */
+  async enrichGamesWithIgdbMedia(games: any[]): Promise<any[]> {
+    if (!Array.isArray(games) || games.length === 0) return games;
+
+    return Promise.all(
+      games.map(async (g) => {
+        try {
+          // If game already has an IGDB-hosted cover, don't overwrite
+          if (g.coverUrl?.includes('images.igdb.com')) {
+            return g;
+          }
+
+          const media = await this.searchGameMediaByTitle(g.name);
+          if (media?.coverUrl) {
+            return {
+              ...g,
+              coverUrl: media.coverUrl,
+              bannerUrl: media.bannerUrl || g.bannerUrl,
+              slug: media.slug || g.slug,
+              platforms: g.platforms && g.platforms.length > 0 ? g.platforms : media.platforms,
+              genres: g.genres && g.genres.length > 0 ? g.genres : media.genres
+            };
+          }
+        } catch (err) {
+          console.warn('[IgdbProvider] Error enriching game:', g.name, err);
+        }
+        return g;
+      })
+    );
+  }
+
+  async getGameBySlugOrId(identifier: string): Promise<IgdbGame | null> {
+    const cacheKey = identifier.toLowerCase().trim();
+    const cached = this.gameDetailsCache.get(cacheKey);
+    if (cached && Date.now() - cached.timestamp < 1000 * 60 * 30) {
+      return cached.data;
+    }
+
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) {
+      const fallback =
+        this.getFallbackGames().find((g) => g.slug === identifier || String(g.id) === identifier) ||
+        null;
+      if (fallback && (!fallback.similarGames || fallback.similarGames.length === 0)) {
+        fallback.similarGames = this.getGenreFallbackGames(fallback, 8);
+      }
+      return fallback;
+    }
+
+    try {
+      const isNumeric = /^\d+$/.test(identifier);
+      const whereClause = isNumeric ? `where id = ${identifier};` : `where slug = "${identifier}";`;
+
+      const body = `
+        fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+               artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+               genres.id, genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+               first_release_date, rating, aggregated_rating,
+               involved_companies.developer, involved_companies.publisher, involved_companies.company.name,
+               similar_games.name, similar_games.slug, similar_games.category, similar_games.summary, similar_games.cover.image_id, similar_games.cover.url,
+               similar_games.rating, similar_games.genres.name, similar_games.platforms.name, similar_games.first_release_date;
+        ${whereClause}
+        limit 1;
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (!res.ok) {
+        return null;
+      }
+
+      let rawGames = (await res.json()) as IgdbRawGame[];
+      if (!rawGames || rawGames.length === 0) {
+        if (!isNumeric) {
+          // If direct slug lookup had no matches (e.g. "eafc"), fallback to IGDB search
+          const searchBody = `
+            fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+                   artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+                   genres.id, genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+                   first_release_date, rating, aggregated_rating,
+                   involved_companies.developer, involved_companies.publisher, involved_companies.company.name,
+                   similar_games.name, similar_games.slug, similar_games.category, similar_games.summary, similar_games.cover.image_id, similar_games.cover.url,
+                   similar_games.rating, similar_games.genres.name, similar_games.platforms.name, similar_games.first_release_date;
+            search "${identifier.replace(/"/g, '')}";
+            limit 1;
+          `;
+          const searchRes = await fetch('https://api.igdb.com/v4/games', {
+            method: 'POST',
+            headers: {
+              'Client-ID': this.clientId,
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'text/plain'
+            },
+            body: searchBody
+          });
+          if (searchRes.ok) {
+            rawGames = (await searchRes.json()) as IgdbRawGame[];
+          }
+        }
+      }
+
+      if (!rawGames || rawGames.length === 0) {
+        return null;
+      }
+
+      const transformed = this.transformGame(rawGames[0]);
+
+      // Enrich and strictly filter similar games by genre & vibe (e.g. Sports only for sports, Cozy only for cozy)
+      transformed.similarGames = await this.filterAndEnrichSimilarGames(
+        transformed,
+        transformed.similarGames || [],
+        25
+      );
+
+      this.gameDetailsCache.set(cacheKey, { data: transformed, timestamp: Date.now() });
+      if (transformed.slug) {
+        this.gameDetailsCache.set(transformed.slug.toLowerCase().trim(), {
+          data: transformed,
+          timestamp: Date.now()
+        });
+      }
+      this.gameDetailsCache.set(String(transformed.id), {
+        data: transformed,
+        timestamp: Date.now()
+      });
+
+      return transformed;
+    } catch {
+      return null;
+    }
+  }
+
+  async filterAndEnrichSimilarGames(
+    game: IgdbGame,
+    rawSimilar: IgdbGame[] = [],
+    limit = 25
+  ): Promise<IgdbGame[]> {
+    const slug = game.slug.toLowerCase();
+    const name = game.name.toLowerCase();
+    const genres = (game.genres || []).map((g) => g.toLowerCase());
+
+    const isSports =
+      genres.some((g) => g.includes('sport') || g.includes('corrida') || g.includes('racing')) ||
+      slug.includes('fc') ||
+      slug.includes('fifa') ||
+      slug.includes('nba') ||
+      slug.includes('f1') ||
+      slug.includes('madden') ||
+      slug.includes('pes') ||
+      slug.includes('skate') ||
+      slug.includes('wwe') ||
+      name.includes('sports') ||
+      name.includes('football') ||
+      name.includes('soccer');
+
+    const cozyKeywords = [
+      'stardew',
+      'animal-crossing',
+      'farm',
+      'harvest',
+      'keeper',
+      'coral-island',
+      'slime-rancher',
+      'moonlighter',
+      'dave-the-diver',
+      'sun-haven',
+      'mistria',
+      'pacha',
+      'cozy',
+      'unpacking',
+      'potion-permit',
+      'spiritfarer',
+      'dorfromantik',
+      'coffee-talk',
+      'townscaper',
+      'a-short-hike',
+      'travellers-rest'
+    ];
+
+    const isCozy =
+      !isSports &&
+      (cozyKeywords.some((k) => slug.includes(k) || name.includes(k)) ||
+        ((slug.includes('valley') || name.includes('valley')) &&
+          genres.some((g) => g.includes('rpg') || g.includes('indie'))));
+
+    if (isSports) {
+      const sportsKeywords = [
+        'fifa',
+        'pes',
+        'efootball',
+        'nba',
+        'nfl',
+        'f1',
+        'madden',
+        'football',
+        'soccer',
+        'tennis',
+        'skate',
+        'hockey',
+        'golf',
+        'wwe',
+        'wrestling',
+        'racing',
+        'corrida',
+        'esporte',
+        'sport',
+        'wrc',
+        'nascar',
+        'nhl',
+        'mlb',
+        'pga',
+        'pro evolution',
+        'topspin',
+        'rocket league',
+        'gran turismo',
+        'forza'
+      ];
+
+      const filtered = rawSimilar.filter((g) => {
+        if (this.isDlcOrExpansion(g.name, g.slug, g.category)) return false;
+        const gName = g.name.toLowerCase();
+        const gSlug = g.slug.toLowerCase();
+        const gGenres = (g.genres || []).map((gen) => gen.toLowerCase());
+        const hasSportGenre = gGenres.some(
+          (gen) =>
+            gen.includes('sport') ||
+            gen.includes('esporte') ||
+            gen.includes('corrida') ||
+            gen.includes('racing')
+        );
+        const hasSportKeyword = sportsKeywords.some((k) => gName.includes(k) || gSlug.includes(k));
+        return (hasSportGenre || hasSportKeyword) && g.slug !== game.slug;
+      });
+
+      const fallbackSports = this.getGenreFallbackGames(game, 30);
+      const existingSlugs = new Set(filtered.map((g) => g.slug));
+      existingSlugs.add(game.slug);
+
+      for (const fallback of fallbackSports) {
+        if (
+          !existingSlugs.has(fallback.slug) &&
+          !this.isDlcOrExpansion(fallback.name, fallback.slug, fallback.category)
+        ) {
+          filtered.push(fallback);
+          existingSlugs.add(fallback.slug);
+        }
+      }
+      return filtered.slice(0, limit);
+    }
+
+    if (isCozy) {
+      // Exclude violent, dark, or gritty games that community tags mistakenly attached to cozy games
+      const nonCozyKeywords = [
+        'rust',
+        'police',
+        'contraband',
+        'morta',
+        'hollow',
+        'prepper',
+        'witcher',
+        'doom',
+        'dark souls',
+        'resident evil',
+        'horror',
+        'warfare',
+        'cyberpunk',
+        'grand theft',
+        'bloodborne',
+        'elden'
+      ];
+
+      const filtered = rawSimilar.filter((g) => {
+        if (this.isDlcOrExpansion(g.name, g.slug, g.category)) return false;
+        const gName = g.name.toLowerCase();
+        const gSlug = g.slug.toLowerCase();
+        const isExcluded = nonCozyKeywords.some((k) => gName.includes(k) || gSlug.includes(k));
+        if (isExcluded) return false;
+        return g.slug !== game.slug;
+      });
+
+      const fallbackCozy = this.getGenreFallbackGames(game, 30);
+      const existingSlugs = new Set(filtered.map((g) => g.slug));
+      existingSlugs.add(game.slug);
+
+      for (const fallback of fallbackCozy) {
+        if (
+          !existingSlugs.has(fallback.slug) &&
+          !this.isDlcOrExpansion(fallback.name, fallback.slug, fallback.category)
+        ) {
+          filtered.push(fallback);
+          existingSlugs.add(fallback.slug);
+        }
+      }
+      return filtered.slice(0, limit);
+    }
+
+    // For all other games (RPG, Action, Adventure, Shooter, etc.):
+    const cleanRaw = rawSimilar.filter(
+      (g) => !this.isDlcOrExpansion(g.name, g.slug, g.category) && g.slug !== game.slug
+    );
+
+    const filtered = [...cleanRaw];
+    const existingSlugs = new Set(filtered.map((g) => g.slug));
+    existingSlugs.add(game.slug);
+
+    // If IGDB only returned 10 similar games, enrich with games from the same genre
+    if (filtered.length < limit) {
+      try {
+        const genreGames = await this.queryGamesByGenre(game.genreIds || [], game.id, limit);
+        for (const g of genreGames) {
+          if (!existingSlugs.has(g.slug) && !this.isDlcOrExpansion(g.name, g.slug, g.category)) {
+            filtered.push(g);
+            existingSlugs.add(g.slug);
+          }
+        }
+      } catch (err) {
+        console.warn('Error querying genre games in filterAndEnrichSimilarGames:', err);
+      }
+    }
+
+    // If still under limit, backfill with curated genre-appropriate titles
+    if (filtered.length < limit) {
+      const fallbackList = this.getGenreFallbackGames(game, 30);
+      for (const f of fallbackList) {
+        if (!existingSlugs.has(f.slug) && !this.isDlcOrExpansion(f.name, f.slug, f.category)) {
+          filtered.push(f);
+          existingSlugs.add(f.slug);
+        }
+      }
+    }
+
+    return filtered.slice(0, limit);
+  }
+
+  async getRecommendedGames(game: IgdbGame, limit = 8): Promise<IgdbGame[]> {
+    const recCacheKey = `${game.slug.toLowerCase()}_${limit}`;
+    const cachedRec = this.recommendedCache.get(recCacheKey);
+    if (cachedRec && Date.now() - cachedRec.timestamp < 1000 * 60 * 30) {
+      return cachedRec.data;
+    }
+
+    const slug = game.slug.toLowerCase();
+    const name = game.name.toLowerCase();
+    const genres = (game.genres || []).map((g) => g.toLowerCase());
+
+    const isSports =
+      genres.some((g) => g.includes('sport') || g.includes('corrida') || g.includes('racing')) ||
+      slug.includes('fc') ||
+      slug.includes('fifa') ||
+      slug.includes('nba') ||
+      slug.includes('f1') ||
+      slug.includes('madden') ||
+      slug.includes('pes') ||
+      slug.includes('skate') ||
+      slug.includes('wwe') ||
+      name.includes('sports') ||
+      name.includes('football') ||
+      name.includes('soccer');
+
+    const cozyKeywords = [
+      'stardew',
+      'animal-crossing',
+      'farm',
+      'harvest',
+      'keeper',
+      'coral-island',
+      'slime-rancher',
+      'moonlighter',
+      'dave-the-diver',
+      'sun-haven',
+      'mistria',
+      'pacha',
+      'cozy',
+      'unpacking',
+      'potion-permit',
+      'spiritfarer',
+      'dorfromantik',
+      'coffee-talk',
+      'townscaper',
+      'a-short-hike',
+      'travellers-rest'
+    ];
+
+    const isCozy =
+      !isSports &&
+      (cozyKeywords.some((k) => slug.includes(k) || name.includes(k)) ||
+        ((slug.includes('valley') || name.includes('valley')) &&
+          genres.some((g) => g.includes('rpg') || g.includes('indie'))));
+
+    let finalRecs: IgdbGame[] = [];
+
+    // For sports and cozy games, return strictly tailored curated suggestions
+    if (isSports || isCozy) {
+      finalRecs = this.getGenreFallbackGames(game, limit);
+    } else {
+      const genreIds = game.genreIds || [];
+      const results = await this.queryGamesByGenre(genreIds, game.id, limit);
+
+      if (results.length > 0) {
+        finalRecs = results;
+      } else {
+        finalRecs = this.getGenreFallbackGames(game, limit);
+      }
+    }
+
+    this.recommendedCache.set(recCacheKey, { data: finalRecs, timestamp: Date.now() });
+    return finalRecs;
+  }
+
+  private async queryGamesByGenre(
+    genreIds: number[],
+    excludeId: number | string,
+    limit = 8
+  ): Promise<IgdbGame[]> {
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId || genreIds.length === 0) {
+      return [];
+    }
+
+    try {
+      // Prioritize specific defining genres (Sport: 14, Racing: 10, Simulator: 13, Shooter: 5, etc.)
+      // over generic RPG (12) or Adventure (31)
+      const PRIORITY_GENRES = [14, 10, 13, 5, 4, 9, 15, 32];
+      const targetGenre = genreIds.find((id) => PRIORITY_GENRES.includes(id)) || genreIds[0];
+
+      const body = `
+        fields name, slug, summary, category, cover.image_id, cover.url,
+               genres.id, genres.name, platforms.name, game_modes.name, first_release_date, rating;
+        where genres = (${targetGenre}) & id != ${excludeId} & cover != null & category = (0, 8, 9) & rating > 70;
+        sort rating desc;
+        limit ${limit};
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (res.ok) {
+        const raw = (await res.json()) as IgdbRawGame[];
+        if (Array.isArray(raw) && raw.length > 0) {
+          return raw
+            .map((r) => this.transformGame(r))
+            .filter((g) => !this.isDlcOrExpansion(g.name, g.slug, g.category));
+        }
+      }
+    } catch (err) {
+      console.warn('Error querying games by genre from IGDB:', err);
+    }
+
+    return [];
+  }
+
+  getGenreFallbackGames(game: IgdbGame, limit = 25): IgdbGame[] {
+    const slug = game.slug.toLowerCase();
+    const name = game.name.toLowerCase();
+    const genres = (game.genres || []).map((g) => g.toLowerCase());
+
+    const isSports =
+      genres.some((g) => g.includes('sport') || g.includes('corrida') || g.includes('racing')) ||
+      slug.includes('fc') ||
+      slug.includes('fifa') ||
+      slug.includes('nba') ||
+      slug.includes('f1') ||
+      slug.includes('madden') ||
+      slug.includes('pes') ||
+      slug.includes('skate') ||
+      slug.includes('wwe') ||
+      name.includes('sports') ||
+      name.includes('football') ||
+      name.includes('soccer');
+
+    const cozyKeywords = [
+      'stardew',
+      'animal-crossing',
+      'farm',
+      'harvest',
+      'keeper',
+      'coral-island',
+      'slime-rancher',
+      'moonlighter',
+      'dave-the-diver',
+      'sun-haven',
+      'mistria',
+      'pacha',
+      'cozy',
+      'unpacking',
+      'potion-permit',
+      'spiritfarer',
+      'dorfromantik',
+      'coffee-talk',
+      'townscaper',
+      'a-short-hike',
+      'travellers-rest'
+    ];
+
+    const isCozy =
+      !isSports &&
+      (cozyKeywords.some((k) => slug.includes(k) || name.includes(k)) ||
+        ((slug.includes('valley') || name.includes('valley')) &&
+          genres.some((g) => g.includes('rpg') || g.includes('indie'))));
+
+    const isShooter =
+      genres.some((g) => g.includes('shooter')) ||
+      slug.includes('duty') ||
+      slug.includes('apex') ||
+      slug.includes('doom') ||
+      slug.includes('cyberpunk');
+
+    if (isSports) {
+      return [
+        {
+          id: 3001,
+          name: 'EA SPORTS FC 24',
+          slug: 'ea-sports-fc-24',
+          summary: 'O Jogo de Todo Mundo trazendo o futebol mais realista do planeta.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6q78.webp',
+          genres: ['Esporte', 'Simulador'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 4.2
+        },
+        {
+          id: 3002,
+          name: 'eFootball 2024',
+          slug: 'efootball-2024',
+          summary: 'Uma nova era de futebol virtual da Konami para os amantes do esporte.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co71c3.webp',
+          genres: ['Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 3.8
+        },
+        {
+          id: 3003,
+          name: 'NBA 2K24',
+          slug: 'nba-2k24',
+          summary:
+            'Experimente a cultura do basquete com realismo inovador e o legado de Kobe Bryant.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6r00.webp',
+          genres: ['Esporte', 'Simulador'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 4.0
+        },
+        {
+          id: 3004,
+          name: 'Rocket League',
+          slug: 'rocket-league',
+          summary: 'Futebol com carros movidos a foguete em alta octanagem.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co5176.webp',
+          genres: ['Esporte', 'Ação'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2015',
+          rating: 4.6
+        },
+        {
+          id: 3005,
+          name: 'F1 24',
+          slug: 'f1-24',
+          summary:
+            'Sinta-se mais próximo do grid do que nunca no jogo oficial do Campeonato de Fórmula 1.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co835b.webp',
+          genres: ['Corrida', 'Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2024',
+          rating: 4.3
+        },
+        {
+          id: 3006,
+          name: 'TopSpin 2K25',
+          slug: 'topspin-2k25',
+          summary: 'O clássico do tênis retorna com lendas do esporte e partidas intensas.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co811o.webp',
+          genres: ['Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2024',
+          rating: 4.1
+        },
+        {
+          id: 3007,
+          name: "Tony Hawk's Pro Skater 1 + 2",
+          slug: 'tony-hawks-pro-skater-1-plus-2',
+          summary: 'Reviva as manobras e a trilha sonora épica do skate nos remakes definitivos.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co204m.webp',
+          genres: ['Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2020',
+          rating: 4.8
+        },
+        {
+          id: 3008,
+          name: 'WWE 2K24',
+          slug: 'wwe-2k24',
+          summary:
+            'Celebre 40 anos de WrestleMania com os maiores combates da história do wrestling.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co7v5k.webp',
+          genres: ['Esporte', 'Luta'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2024',
+          rating: 4.2
+        },
+        {
+          id: 3009,
+          name: 'FIFA 23',
+          slug: 'fifa-23',
+          summary: 'A tecnologia HyperMotion2 leva o Maior Jogo do Mundo aos gramados virtuais.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co50a6.webp',
+          genres: ['Esporte', 'Simulador'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2022',
+          rating: 4.1
+        },
+        {
+          id: 3010,
+          name: 'Madden NFL 24',
+          slug: 'madden-nfl-24',
+          summary: 'O controle tático do futebol americano com a evolução do FieldSENSE.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6qg8.webp',
+          genres: ['Esporte', 'Simulador'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 3.9
+        },
+        {
+          id: 3011,
+          name: 'Gran Turismo 7',
+          slug: 'gran-turismo-7',
+          summary: 'O simulador de corrida real definitivo com mais de 400 carros lendários.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co49x5.webp',
+          genres: ['Corrida', 'Simulador'],
+          platforms: ['PlayStation 5', 'PlayStation 4'],
+          releaseYear: '2022',
+          rating: 4.7
+        },
+        {
+          id: 3012,
+          name: 'Forza Horizon 5',
+          slug: 'forza-horizon-5',
+          summary:
+            'Explore as paisagens vibrantes do México em um festival automobilístico aberto sem limites.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co3ofw.webp',
+          genres: ['Corrida', 'Aventura'],
+          platforms: ['PC', 'Xbox Series X|S', 'Xbox One'],
+          releaseYear: '2021',
+          rating: 4.8
+        },
+        {
+          id: 3013,
+          name: 'Football Manager 2024',
+          slug: 'football-manager-2024',
+          summary:
+            'Construa uma equipe de nível mundial e lidere seu clube à glória absoluta no futebol.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co759r.webp',
+          genres: ['Simulador', 'Estratégia', 'Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 4.5
+        },
+        {
+          id: 3014,
+          name: 'Riders Republic',
+          slug: 'riders-republic',
+          summary:
+            'Salte no imenso parque esportivo multiplayer com esqui, snowboard, bike e wingsuit.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2k3e.webp',
+          genres: ['Esporte', 'Corrida'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2021',
+          rating: 4.2
+        },
+        {
+          id: 3015,
+          name: 'Skate 3',
+          slug: 'skate-3',
+          summary: 'O ápice da física e das manobras cooperativas de skate em Port Carverton.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1x9a.webp',
+          genres: ['Esporte'],
+          platforms: ['PlayStation 3', 'Xbox 360'],
+          releaseYear: '2010',
+          rating: 4.6
+        },
+        {
+          id: 3016,
+          name: 'PGA TOUR 2K23',
+          slug: 'pga-tour-2k23',
+          summary:
+            'Leve suas tacadas para o PGA TOUR e dispute contra profissionais do golfe mundial.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co580e.webp',
+          genres: ['Esporte', 'Simulador'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2022',
+          rating: 4.1
+        },
+        {
+          id: 3017,
+          name: 'Tennis World Tour 2',
+          slug: 'tennis-world-tour-2',
+          summary:
+            'Jogue como os maiores tenistas do mundo ou crie seu próprio atleta para dominar o ranking.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2k1o.webp',
+          genres: ['Esporte'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2020',
+          rating: 4.0
+        },
+        {
+          id: 3018,
+          name: 'NHL 24',
+          slug: 'nhl-24',
+          summary:
+            'Sinta toda a intensidade do hóquei no gelo com a nova Exhaust Engine da EA SPORTS.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co72f3.webp',
+          genres: ['Esporte'],
+          platforms: ['PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 4.2
+        },
+        {
+          id: 3019,
+          name: 'MLB The Show 24',
+          slug: 'mlb-the-show-24',
+          summary: 'Viva seus sonhos de beisebol com momentos decisivos e lendas da MLB.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co7s8q.webp',
+          genres: ['Esporte'],
+          platforms: ['PlayStation 5', 'Xbox Series X|S', 'Nintendo Switch'],
+          releaseYear: '2024',
+          rating: 4.4
+        },
+        {
+          id: 3020,
+          name: 'WRC Generations',
+          slug: 'wrc-generations',
+          summary: 'Encare todos os desafios do rali mais completo e realista já criado.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co52a7.webp',
+          genres: ['Corrida', 'Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2022',
+          rating: 4.3
+        },
+        {
+          id: 3021,
+          name: 'Session: Skate Sim',
+          slug: 'session-skate-sim',
+          summary:
+            'Feito por e para skatistas, experimente o controle duplo com os analógicos para manobras ultra precisas.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co50a7.webp',
+          genres: ['Simulador', 'Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2022',
+          rating: 4.2
+        },
+        {
+          id: 3022,
+          name: 'AO Tennis 2',
+          slug: 'ao-tennis-2',
+          summary:
+            'O jogo de tênis oficial do Australian Open com modo carreira profundo e criação de quadras.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1xcr.webp',
+          genres: ['Esporte'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2020',
+          rating: 4.1
+        },
+        {
+          id: 3023,
+          name: 'DIRT 5',
+          slug: 'dirt-5',
+          summary: 'Corridas off-road cheias de estilo, adrenalina e pistas dinâmicas pelo mundo.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co204b.webp',
+          genres: ['Corrida', 'Esporte'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2020',
+          rating: 4.3
+        },
+        {
+          id: 3024,
+          name: 'Ride 5',
+          slug: 'ride-5',
+          summary:
+            'Acelere seu motor e sinta a emoção de pilotar as motocicletas mais desejadas da história.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6qg9.webp',
+          genres: ['Corrida', 'Esporte', 'Simulador'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 4.2
+        }
+      ].slice(0, limit);
+    }
+
+    if (isCozy) {
+      return [
+        {
+          id: 4001,
+          name: 'Animal Crossing: New Horizons',
+          slug: 'animal-crossing-new-horizons',
+          summary:
+            'Escape para uma ilha deserta e crie seu próprio paraíso nesta experiência relaxante.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co72i4.webp',
+          genres: ['Simulador', 'Aventura'],
+          platforms: ['Nintendo Switch'],
+          releaseYear: '2020',
+          rating: 4.9
+        },
+        {
+          id: 4002,
+          name: 'Graveyard Keeper',
+          slug: 'graveyard-keeper',
+          summary: 'A simulação de gerenciamento de cemitério medieval mais imprecisa do ano.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1xcr.webp',
+          genres: ['Simulador', 'RPG', 'Indie'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2018',
+          rating: 4.4
+        },
+        {
+          id: 4003,
+          name: 'Dave the Diver',
+          slug: 'dave-the-diver',
+          summary:
+            'Explore o mar durante o dia e administre um restaurante de sushi movimentado à noite.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6t84.webp',
+          genres: ['Aventura', 'Simulador', 'RPG'],
+          platforms: ['PC', 'PlayStation 5', 'Nintendo Switch'],
+          releaseYear: '2023',
+          rating: 4.8
+        },
+        {
+          id: 4004,
+          name: 'Slime Rancher 2',
+          slug: 'slime-rancher-2',
+          summary:
+            'Continue as aventuras de Beatrix LeBeau ao viajar pela Rainbow Island criando slimes adoráveis.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co5q42.webp',
+          genres: ['Aventura', 'Indie', 'Simulador'],
+          platforms: ['PC', 'Xbox Series X|S', 'PlayStation 5'],
+          releaseYear: '2022',
+          rating: 4.6
+        },
+        {
+          id: 4005,
+          name: 'Coral Island',
+          slug: 'coral-island',
+          summary:
+            'Construa sua fazenda dos sonhos, cuide dos animais e restaure recifes de corais.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co7j3g.webp',
+          genres: ['Simulador', 'RPG'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2023',
+          rating: 4.5
+        },
+        {
+          id: 4006,
+          name: 'Moonlighter',
+          slug: 'moonlighter',
+          summary:
+            'Um RPG de ação com elementos rogue-lite sobre a rotina de Will, um lojista corajoso.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1mbi.webp',
+          genres: ['RPG', 'Indie', 'Aventura'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2018',
+          rating: 4.3
+        },
+        {
+          id: 4007,
+          name: 'Sun Haven',
+          slug: 'sun-haven',
+          summary:
+            'Crie sua fazenda e construa relacionamentos com moradores nesta vila mágica cheia de fantasia.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co69p2.webp',
+          genres: ['RPG', 'Simulador', 'Indie'],
+          platforms: ['PC'],
+          releaseYear: '2023',
+          rating: 4.6
+        },
+        {
+          id: 4008,
+          name: 'Terraria',
+          slug: 'terraria',
+          summary:
+            'Cave, lute, explore e construa neste jogo de aventura sandbox 2D aclamado no mundo todo.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1r7f.webp',
+          genres: ['Aventura', 'Indie', 'Plataforma'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2011',
+          rating: 4.9
+        },
+        {
+          id: 4009,
+          name: 'Roots of Pacha',
+          slug: 'roots-of-pacha',
+          summary:
+            'Uma simulação de fazenda e vida comunitária acolhedora ambientada na Idade da Pedra.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co69f2.webp',
+          genres: ['Simulador', 'RPG', 'Indie'],
+          platforms: ['PC', 'PlayStation 5', 'Nintendo Switch'],
+          releaseYear: '2023',
+          rating: 4.7
+        },
+        {
+          id: 4010,
+          name: 'Cozy Grove',
+          slug: 'cozy-grove',
+          summary:
+            'Explore uma ilha assombrada e traga cor e vida aos fantasmas fofos dos ursos locais.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2w6a.webp',
+          genres: ['Aventura', 'Simulador', 'Indie'],
+          platforms: ['PC', 'PlayStation 4', 'Nintendo Switch'],
+          releaseYear: '2021',
+          rating: 4.5
+        },
+        {
+          id: 4011,
+          name: 'Unpacking',
+          slug: 'unpacking',
+          summary: 'Um jogo zen sobre desempacotar caixas e montar lares através dos anos.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co3w6x.webp',
+          genres: ['Quebra-cabeça', 'Indie'],
+          platforms: ['PC', 'PlayStation 5', 'Nintendo Switch'],
+          releaseYear: '2021',
+          rating: 4.8
+        },
+        {
+          id: 4012,
+          name: 'Spiritfarer',
+          slug: 'spiritfarer',
+          summary:
+            'Um jogo de gerenciamento acolhedor sobre a morte e a despedida de amigos queridos.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co22b8.webp',
+          genres: ['Aventura', 'Simulador', 'Indie'],
+          platforms: ['PC', 'PlayStation 4', 'Nintendo Switch'],
+          releaseYear: '2020',
+          rating: 4.9
+        },
+        {
+          id: 4013,
+          name: 'Dorfromantik',
+          slug: 'dorfromantik',
+          summary:
+            'Construa paisagens rurais pacíficas e crie aldeias idílicas colocando ladrilhos hexagonais.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co3i06.webp',
+          genres: ['Estratégia', 'Quebra-cabeça', 'Indie'],
+          platforms: ['PC', 'Nintendo Switch'],
+          releaseYear: '2022',
+          rating: 4.7
+        },
+        {
+          id: 4014,
+          name: 'A Short Hike',
+          slug: 'a-short-hike',
+          summary:
+            'Caminhe, voe e suba montanhas relaxantes neste mundinho encantador e aconchegante.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1xbt.webp',
+          genres: ['Aventura', 'Indie'],
+          platforms: ['PC', 'Nintendo Switch', 'PlayStation 4'],
+          releaseYear: '2019',
+          rating: 4.8
+        },
+        {
+          id: 4015,
+          name: 'Ooblets',
+          slug: 'ooblets',
+          summary:
+            'Cultive criaturinhas fofas, participe de batalhas de dança e gerencie sua fazendinha.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co52b9.webp',
+          genres: ['Simulador', 'RPG', 'Indie'],
+          platforms: ['PC', 'Xbox Series X|S', 'Nintendo Switch'],
+          releaseYear: '2022',
+          rating: 4.6
+        },
+        {
+          id: 4016,
+          name: 'Wylde Flowers',
+          slug: 'wylde-flowers',
+          summary:
+            'Junte-se a Tara em uma jornada mágica para se tornar uma bruxa acolhedora em sua fazenda.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co4x4b.webp',
+          genres: ['Simulador', 'Aventura', 'Indie'],
+          platforms: ['PC', 'Nintendo Switch', 'Apple Arcade'],
+          releaseYear: '2022',
+          rating: 4.8
+        },
+        {
+          id: 4017,
+          name: 'Fae Farm',
+          slug: 'fae-farm',
+          summary: 'Escape para o mundo mágico de Azoria e construa seu lar de fadas com amigos.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co69f3.webp',
+          genres: ['RPG', 'Simulador'],
+          platforms: ['PC', 'Nintendo Switch', 'PlayStation 5'],
+          releaseYear: '2023',
+          rating: 4.3
+        },
+        {
+          id: 4018,
+          name: 'Dinkum',
+          slug: 'dinkum',
+          summary:
+            'Comece uma nova vida relaxante no outback australiano construindo sua cidade e fazenda.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co50a8.webp',
+          genres: ['Simulador', 'RPG', 'Indie'],
+          platforms: ['PC'],
+          releaseYear: '2022',
+          rating: 4.7
+        },
+        {
+          id: 4019,
+          name: 'Rune Factory 4 Special',
+          slug: 'rune-factory-4-special',
+          summary:
+            'O clássico RPG de vida no campo, cultivo e relacionamentos mágicos remasterizado.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1r7e.webp',
+          genres: ['RPG', 'Simulador'],
+          platforms: ['PC', 'Nintendo Switch', 'PlayStation 4', 'Xbox One'],
+          releaseYear: '2019',
+          rating: 4.6
+        },
+        {
+          id: 4020,
+          name: 'My Time at Sandrock',
+          slug: 'my-time-at-sandrock',
+          summary:
+            'Viaje para a comunidade desértica de Sandrock e ajude a cidade a prosperar como construtor.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6r01.webp',
+          genres: ['RPG', 'Simulador', 'Aventura'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S', 'Nintendo Switch'],
+          releaseYear: '2023',
+          rating: 4.7
+        },
+        {
+          id: 4021,
+          name: 'Slime Rancher',
+          slug: 'slime-rancher',
+          summary: 'Explore um planeta colorido e alienígena criando slimes alegres e pulitantes.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1xcr.webp',
+          genres: ['Aventura', 'Indie', 'Simulador'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+          releaseYear: '2017',
+          rating: 4.8
+        },
+        {
+          id: 4022,
+          name: 'Kynseed',
+          slug: 'kynseed',
+          summary:
+            'Um sandbox RPG 2D feito por ex-desenvolvedores de Fable com ciclos de vida e fazenda.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co52b8.webp',
+          genres: ['RPG', 'Simulador', 'Indie'],
+          platforms: ['PC'],
+          releaseYear: '2022',
+          rating: 4.4
+        },
+        {
+          id: 4023,
+          name: 'Travellers Rest',
+          slug: 'travellers-rest',
+          summary:
+            'Gerencie sua própria taverna medieval aconchegante, produza cervejas e cultive ingredientes.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co204c.webp',
+          genres: ['Simulador', 'RPG', 'Indie'],
+          platforms: ['PC'],
+          releaseYear: '2020',
+          rating: 4.6
+        }
+      ].slice(0, limit);
+    }
+
+    if (isShooter) {
+      const shooterGames: IgdbGame[] = [
+        {
+          id: 5001,
+          name: 'Doom Eternal',
+          slug: 'doom-eternal',
+          summary:
+            'Os exércitos do inferno invadiram a Terra. Torne-se o Slayer e destrua os demônios.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co29be.webp',
+          genres: ['Tiro (Shooter)'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2020',
+          rating: 4.8
+        },
+        {
+          id: 5002,
+          name: 'Titanfall 2',
+          slug: 'titanfall-2',
+          summary:
+            'Piloto e Titã se unem como nunca nesta obra-prima do FPS com mobilidade sem igual.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1xbo.webp',
+          genres: ['Tiro (Shooter)'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+          releaseYear: '2016',
+          rating: 4.9
+        },
+        {
+          id: 5003,
+          name: 'Apex Legends',
+          slug: 'apex-legends',
+          summary:
+            'Domine um elenco crescente de lendas com habilidades poderosas nesta batalha estratégica.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2044.webp',
+          genres: ['Tiro (Shooter)', 'Ação'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2019',
+          rating: 4.5
+        },
+        {
+          id: 5004,
+          name: 'Destiny 2',
+          slug: 'destiny-2',
+          summary: 'Mergulhe no mundo de Destiny 2 para explorar os mistérios do sistema solar.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1t98.webp',
+          genres: ['Tiro (Shooter)', 'RPG'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2017',
+          rating: 4.4
+        },
+        {
+          id: 5005,
+          name: 'Halo Infinite',
+          slug: 'halo-infinite',
+          summary: 'O Master Chief retorna na maior aventura e campanha da icônica franquia Halo.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co214o.webp',
+          genres: ['Tiro (Shooter)'],
+          platforms: ['PC', 'Xbox Series X|S', 'Xbox One'],
+          releaseYear: '2021',
+          rating: 4.3
+        },
+        {
+          id: 5006,
+          name: 'Overwatch 2',
+          slug: 'overwatch-2',
+          summary: 'Heróis lendários em confrontos 5v5 cheios de ação e estratégia.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co4t4b.webp',
+          genres: ['Tiro (Shooter)'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S', 'Nintendo Switch'],
+          releaseYear: '2022',
+          rating: 4.1
+        },
+        {
+          id: 5007,
+          name: "Tom Clancy's Rainbow Six Siege",
+          slug: 'tom-clancys-rainbow-six-siege',
+          summary:
+            'O clássico combate tático em equipe com operadores especializados e destruição de ambientes.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1rc7.webp',
+          genres: ['Tiro (Shooter)', 'Tático'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2015',
+          rating: 4.6
+        },
+        {
+          id: 5008,
+          name: 'Counter-Strike 2',
+          slug: 'counter-strike-2',
+          summary: 'O maior avanço técnico na história da lendária série de tiro tático da Valve.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co695g.webp',
+          genres: ['Tiro (Shooter)'],
+          platforms: ['PC'],
+          releaseYear: '2023',
+          rating: 4.7
+        },
+        {
+          id: 5009,
+          name: 'BioShock Infinite',
+          slug: 'bioshock-infinite',
+          summary:
+            'Voe para a cidade flutuante de Columbia em um clássico conto de mistério e ação frenética.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1xbc.webp',
+          genres: ['Tiro (Shooter)', 'Aventura'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+          releaseYear: '2013',
+          rating: 4.9
+        },
+        {
+          id: 5010,
+          name: 'Metro Exodus',
+          slug: 'metro-exodus',
+          summary:
+            'Fuja das ruínas do metrô de Moscou em uma jornada pós-apocalíptica pela imensidão russa.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1m1z.webp',
+          genres: ['Tiro (Shooter)', 'Ação'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2019',
+          rating: 4.7
+        },
+        {
+          id: 5011,
+          name: 'Deep Rock Galactic',
+          slug: 'deep-rock-galactic',
+          summary:
+            'Anões espaciais badass, cavernas 100% destrutíveis e hordas infinitas de monstros alienígenas.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2jvd.webp',
+          genres: ['Tiro (Shooter)', 'Indie'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2020',
+          rating: 4.8
+        },
+        {
+          id: 5012,
+          name: 'Borderlands 3',
+          slug: 'borderlands-3',
+          summary:
+            'O rei dos looter-shooters com bilhões de armas extravagantes e caos interplanetário.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1s4c.webp',
+          genres: ['Tiro (Shooter)', 'RPG'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2019',
+          rating: 4.4
+        },
+        {
+          id: 5013,
+          name: 'Hunt: Showdown',
+          slug: 'hunt-showdown',
+          summary: 'PvPvE de alta tensão e terror sobrenatural nos pântanos sombrios da Louisiana.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1ndb.webp',
+          genres: ['Tiro (Shooter)'],
+          platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+          releaseYear: '2019',
+          rating: 4.6
+        },
+        {
+          id: 5014,
+          name: 'Wolfenstein II: The New Colossus',
+          slug: 'wolfenstein-ii-the-new-colossus',
+          summary:
+            'Lidere a segunda Revolução Americana contra o regime opressor nesta campanha épica.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1rb8.webp',
+          genres: ['Tiro (Shooter)', 'Ação'],
+          platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+          releaseYear: '2017',
+          rating: 4.7
+        },
+        {
+          id: 5015,
+          name: 'ULTRAKILL',
+          slug: 'ultrakill',
+          summary:
+            'Um retro-FPS ultra veloz e brutal movido a sangue e habilidades de combo acrobáticas.',
+          coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co22q2.webp',
+          genres: ['Tiro (Shooter)', 'Indie'],
+          platforms: ['PC'],
+          releaseYear: '2020',
+          rating: 4.9
+        }
+      ];
+      return shooterGames
+        .filter((g) => g.slug !== game.slug && !this.isDlcOrExpansion(g.name, g.slug, g.category))
+        .slice(0, limit);
+    }
+
+    // Default RPG / Adventure / Souls
+    const defaultGames: IgdbGame[] = [
+      {
+        id: 119133,
+        name: 'Dark Souls III',
+        slug: 'dark-souls-iii',
+        summary:
+          'Enquanto o fogo se apaga e o mundo cai em ruínas, viaje para um universo repleto de inimigos colossais.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1vce.webp',
+        genres: ['Role-playing (RPG)', 'Aventura'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+        releaseYear: '2016',
+        rating: 4.8
+      },
+      {
+        id: 119134,
+        name: 'Bloodborne',
+        slug: 'bloodborne',
+        summary: 'Enfrente seus medos enquanto busca respostas na antiga cidade de Yharnam.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1rba.webp',
+        genres: ['Role-playing (RPG)', 'Ação'],
+        platforms: ['PlayStation 4'],
+        releaseYear: '2015',
+        rating: 4.9
+      },
+      {
+        id: 119135,
+        name: 'Sekiro: Shadows Die Twice',
+        slug: 'sekiro-shadows-die-twice',
+        summary:
+          'Trace seu próprio caminho para a vingança nesta aventura premiada da FromSoftware.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1rbu.webp',
+        genres: ['Ação', 'Aventura'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+        releaseYear: '2019',
+        rating: 4.9
+      },
+      {
+        id: 119136,
+        name: 'Lies of P',
+        slug: 'lies-of-p',
+        summary:
+          'Um soulslike emocionante que adapta a história de Pinóquio em uma cidade sombria da Belle Époque.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6p64.webp',
+        genres: ['Role-playing (RPG)', 'Aventura'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2023',
+        rating: 4.7
+      },
+      {
+        id: 125174,
+        name: "Baldur's Gate 3",
+        slug: 'baldurs-gate-3',
+        summary: 'Reúna seu grupo e retorne aos Forgotten Realms em um RPG revolucionário.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co670h.webp',
+        genres: ['Role-playing (RPG)', 'Estratégia'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2023',
+        rating: 4.9
+      },
+      {
+        id: 119137,
+        name: 'Monster Hunter: World',
+        slug: 'monster-hunter-world',
+        summary:
+          'Cace monstros majestosos em ecossistemas vivos e use seus despojos para forjar equipamentos lendários.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1iqo.webp',
+        genres: ['Role-playing (RPG)', 'Ação'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+        releaseYear: '2018',
+        rating: 4.7
+      },
+      {
+        id: 119138,
+        name: 'Elden Ring',
+        slug: 'elden-ring',
+        summary:
+          'Levante-se, Maculado, e seja guiado pela graça para brandir o poder do Anel Prístino.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co4jni.webp',
+        genres: ['Role-playing (RPG)', 'Aventura'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2022',
+        rating: 4.9
+      },
+      {
+        id: 119139,
+        name: 'The Witcher 3: Wild Hunt',
+        slug: 'the-witcher-3-wild-hunt',
+        summary:
+          'Torne-se Geralt de Rívia, um caçador de monstros profissional em busca da Criança da Profecia.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1wyy.webp',
+        genres: ['Role-playing (RPG)', 'Aventura'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2015',
+        rating: 4.9
+      },
+      {
+        id: 119140,
+        name: 'Cyberpunk 2077',
+        slug: 'cyberpunk-2077',
+        summary: 'Torne-se um mercenário urbano fora da lei na megalópole futurista de Night City.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co8175.webp',
+        genres: ['Role-playing (RPG)', 'Tiro (Shooter)'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2020',
+        rating: 4.6
+      },
+      {
+        id: 119141,
+        name: 'God of War Ragnarök',
+        slug: 'god-of-war-ragnarok',
+        summary:
+          'Kratos e Atreus embarcam em uma jornada mítica por respostas antes da batalha profetizada.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co5s5v.webp',
+        genres: ['Ação', 'Aventura'],
+        platforms: ['PlayStation 5', 'PlayStation 4', 'PC'],
+        releaseYear: '2022',
+        rating: 4.9
+      },
+      {
+        id: 119142,
+        name: 'Ghost of Tsushima',
+        slug: 'ghost-of-tsushima',
+        summary:
+          'Forje um novo caminho e trave uma guerra não convencional pela liberdade de Tsushima.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2765.webp',
+        genres: ['Ação', 'Aventura'],
+        platforms: ['PC', 'PlayStation 5', 'PlayStation 4'],
+        releaseYear: '2020',
+        rating: 4.9
+      },
+      {
+        id: 119143,
+        name: 'Horizon Zero Dawn',
+        slug: 'horizon-zero-dawn',
+        summary:
+          'Viva a lendária jornada de Aloy para desvendar os mistérios de uma Terra dominada por Máquinas.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2vv5.webp',
+        genres: ['Ação', 'Role-playing (RPG)'],
+        platforms: ['PC', 'PlayStation 4', 'PlayStation 5'],
+        releaseYear: '2017',
+        rating: 4.7
+      },
+      {
+        id: 119144,
+        name: 'Red Dead Redemption 2',
+        slug: 'red-dead-redemption-2',
+        summary:
+          'A épica história de Arthur Morgan e da gangue Van der Linde no crepúsculo do Velho Oeste.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1q1f.webp',
+        genres: ['Aventura', 'Ação'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One'],
+        releaseYear: '2018',
+        rating: 4.9
+      },
+      {
+        id: 119145,
+        name: 'Final Fantasy VII Remake',
+        slug: 'final-fantasy-vii-remake',
+        summary: 'Uma reimaginação espetacular do icônico RPG que definiu uma era dos videogames.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1r83.webp',
+        genres: ['Role-playing (RPG)', 'Ação'],
+        platforms: ['PC', 'PlayStation 5', 'PlayStation 4'],
+        releaseYear: '2020',
+        rating: 4.8
+      },
+      {
+        id: 119146,
+        name: "Dragon's Dogma 2",
+        slug: 'dragons-dogma-2',
+        summary:
+          'Um RPG de ação narrativa onde os jogadores moldam sua própria jornada com peões leais.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6t8s.webp',
+        genres: ['Role-playing (RPG)', 'Ação'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2024',
+        rating: 4.5
+      },
+      {
+        id: 119147,
+        name: 'Persona 5 Royal',
+        slug: 'persona-5-royal',
+        summary:
+          'Coloque a máscara dos Phantom Thieves e realize assaltos épicos nos corações dos corruptos.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1nic.webp',
+        genres: ['Role-playing (RPG)'],
+        platforms: ['PC', 'PlayStation 5', 'Nintendo Switch', 'Xbox Series X|S'],
+        releaseYear: '2019',
+        rating: 4.9
+      },
+      {
+        id: 119148,
+        name: 'NieR:Automata',
+        slug: 'nier-automata',
+        summary:
+          'Os androides 2B, 9S e A2 lutam para recuperar uma distopia abandonada pela humanidade.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1r84.webp',
+        genres: ['Role-playing (RPG)', 'Ação'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+        releaseYear: '2017',
+        rating: 4.9
+      },
+      {
+        id: 119149,
+        name: 'The Elder Scrolls V: Skyrim',
+        slug: 'the-elder-scrolls-v-skyrim',
+        summary:
+          'O clássico RPG de mundo aberto definitivo onde você pode ser quem quiser e fazer o que desejar.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1tnw.webp',
+        genres: ['Role-playing (RPG)', 'Aventura'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+        releaseYear: '2011',
+        rating: 4.8
+      },
+      {
+        id: 119150,
+        name: 'Black Myth: Wukong',
+        slug: 'black-myth-wukong',
+        summary: 'Um RPG de ação enraizado na mitologia chinesa baseado em Jornada ao Oeste.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6s8l.webp',
+        genres: ['Ação', 'Role-playing (RPG)'],
+        platforms: ['PC', 'PlayStation 5'],
+        releaseYear: '2024',
+        rating: 4.8
+      },
+      {
+        id: 119151,
+        name: 'Armored Core VI: Fires of Rubicon',
+        slug: 'armored-core-vi-fires-of-rubicon',
+        summary:
+          'Batalhas mecha em alta velocidade com pilotagem tridimensional e montagens personalizadas.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6u2b.webp',
+        genres: ['Ação', 'Simulador'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2023',
+        rating: 4.7
+      },
+      {
+        id: 119152,
+        name: 'Star Wars Jedi: Survivor',
+        slug: 'star-wars-jedi-survivor',
+        summary:
+          'A história de Cal Kestis continua em um combate cinematográfico através da galáxia.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co655w.webp',
+        genres: ['Ação', 'Aventura'],
+        platforms: ['PC', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2023',
+        rating: 4.6
+      },
+      {
+        id: 119153,
+        name: 'Kingdom Come: Deliverance',
+        slug: 'kingdom-come-deliverance',
+        summary:
+          'Um RPG imersivo em primeira pessoa ambientado no Sacro Império Romano da Idade Média.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1r8c.webp',
+        genres: ['Role-playing (RPG)', 'Aventura'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+        releaseYear: '2018',
+        rating: 4.6
+      },
+      {
+        id: 119154,
+        name: 'Death Stranding',
+        slug: 'death-stranding',
+        summary:
+          'Reconecte uma sociedade despedaçada em uma experiência inovadora de mundo aberto de Hideo Kojima.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1s9v.webp',
+        genres: ['Ação', 'Aventura'],
+        platforms: ['PC', 'PlayStation 5', 'PlayStation 4'],
+        releaseYear: '2019',
+        rating: 4.7
+      },
+      {
+        id: 119155,
+        name: "Demon's Souls",
+        slug: 'demons-souls',
+        summary:
+          'O remake impecável do clássico de fantasia sombria e combate impiedoso no reino de Boletaria.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2e0y.webp',
+        genres: ['Role-playing (RPG)', 'Ação'],
+        platforms: ['PlayStation 5'],
+        releaseYear: '2020',
+        rating: 4.8
+      },
+      {
+        id: 119156,
+        name: 'Hollow Knight',
+        slug: 'hollow-knight',
+        summary:
+          'Explore um vasto reino arruinado de insetos e heróis neste aclamado metroidvania.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co9505.webp',
+        genres: ['Aventura', 'Plataforma', 'Indie'],
+        platforms: ['PC', 'PlayStation 4', 'Xbox One', 'Nintendo Switch'],
+        releaseYear: '2017',
+        rating: 4.9
+      }
+    ];
+    return defaultGames
+      .filter((g) => g.slug !== game.slug && !this.isDlcOrExpansion(g.name, g.slug, g.category))
+      .slice(0, limit);
+  }
+
+  async getPopularGames(limit = 12): Promise<IgdbGame[]> {
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) {
+      return this.getFallbackGames().slice(0, limit);
+    }
+
+    try {
+      const fetchLimit = Math.max(limit * 2, 30);
+      const body = `
+        fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+               artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+               genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+               first_release_date, rating, aggregated_rating, rating_count,
+               involved_companies.developer, involved_companies.publisher, involved_companies.company.name;
+        where rating_count > 100 & cover != null;
+        sort rating_count desc;
+        limit ${fetchLimit};
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (!res.ok) {
+        console.error('IGDB API popular error:', await res.text());
+        return this.getFallbackGames().slice(0, limit);
+      }
+
+      const rawGames = (await res.json()) as IgdbRawGame[];
+      const transformed = rawGames
+        .map((g) => this.transformGame(g))
+        .filter((g) => !this.isDlcOrExpansion(g.name, g.slug, g.category));
+
+      if (transformed.length < limit) {
+        const fallbacks = this.getFallbackGames();
+        for (const f of fallbacks) {
+          if (!transformed.some((t) => t.slug === f.slug)) {
+            transformed.push(f);
+          }
+        }
+      }
+
+      return transformed.slice(0, limit);
+    } catch (err) {
+      console.error('Error fetching popular games from IGDB:', err);
+      return this.getFallbackGames().slice(0, limit);
+    }
+  }
+
+  async getTopRatedGames(limit = 6): Promise<IgdbGame[]> {
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) {
+      return this.getFallbackGames().slice(0, limit);
+    }
+
+    try {
+      const fetchLimit = Math.max(limit * 3, 25);
+      const body = `
+        fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+               artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+               genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+               first_release_date, rating, aggregated_rating, rating_count,
+               involved_companies.developer, involved_companies.publisher, involved_companies.company.name;
+        where rating_count > 500 & cover != null;
+        sort rating desc;
+        limit ${fetchLimit};
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (!res.ok) {
+        return this.getFallbackGames().slice(0, limit);
+      }
+
+      const rawGames = (await res.json()) as IgdbRawGame[];
+      const filtered = rawGames
+        .map((g) => this.transformGame(g))
+        .filter((g) => !this.isDlcOrExpansion(g.name, g.slug, g.category));
+
+      return filtered.slice(0, limit);
+    } catch {
+      return this.getFallbackGames().slice(0, limit);
+    }
+  }
+
+  /**
+   * Generates personalized game recommendations for the "Descubra" tab based on games the user has played.
+   * Supports offset and limit for infinite scroll.
+   */
+  async getPersonalizedDiscoverGames({
+    playedSlugs = [],
+    limit = 18,
+    offset = 0
+  }: {
+    playedSlugs?: string[];
+    limit?: number;
+    offset?: number;
+  }): Promise<{ games: IgdbGame[]; basedOn: string[]; hasMore: boolean }> {
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) {
+      const fallback = this.getFallbackGames();
+      return {
+        games: fallback.slice(offset, offset + limit),
+        basedOn: [],
+        hasMore: offset + limit < fallback.length
+      };
+    }
+
+    try {
+      // 1. Resolve played games to extract their genres and exclude their IDs
+      const playedGames: IgdbGame[] = [];
+      for (const slug of playedSlugs.slice(0, 6)) {
+        const g = await this.getGameBySlugOrId(slug);
+        if (g) playedGames.push(g);
+      }
+
+      const basedOnNames = playedGames.map((g) => g.name);
+      const playedIds = playedGames.map((g) => g.id);
+      const genreSet = new Set<number>();
+      for (const g of playedGames) {
+        for (const id of g.genreIds || []) {
+          genreSet.add(id);
+        }
+      }
+
+      const genres = Array.from(genreSet);
+      let whereClause = 'where cover != null & rating != null & rating_count > 30';
+
+      if (genres.length > 0) {
+        // IGDB syntax for array contains any: (genres = (12) | genres = (31))
+        const genreFilters = genres
+          .slice(0, 4)
+          .map((id) => `genres = (${id})`)
+          .join(' | ');
+        whereClause += ` & (${genreFilters})`;
+      }
+
+      if (playedIds.length > 0) {
+        const idFilters = playedIds.map((id) => `id != ${id}`).join(' & ');
+        whereClause += ` & ${idFilters}`;
+      }
+
+      const fetchCount = Math.max(limit * 3, 60);
+      const body = `
+        fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+               artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+               genres.id, genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+               first_release_date, rating, aggregated_rating, rating_count;
+        ${whereClause};
+        sort rating desc;
+        offset ${offset};
+        limit ${fetchCount};
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (!res.ok) {
+        console.error(
+          '[IgdbProvider] discover query error:',
+          res.status,
+          await res.text(),
+          'Body:',
+          body
+        );
+      } else {
+        const rawGames = (await res.json()) as IgdbRawGame[];
+        const filtered = rawGames
+          .filter((g) => !this.isDlcOrExpansion(g.name, g.slug, g.category))
+          .map((g) => this.transformGame(g));
+
+        // If filtered returned less than limit, supplement with fallback games
+        if (filtered.length < limit) {
+          const fallbacks = this.getFallbackGames();
+          for (const f of fallbacks) {
+            if (
+              !filtered.some((g) => g.id === f.id || g.slug === f.slug) &&
+              !playedIds.includes(f.id)
+            ) {
+              filtered.push(f);
+              if (filtered.length >= limit) break;
+            }
+          }
+        }
+
+        const slice = filtered.slice(0, limit);
+        const hasMore = filtered.length >= limit;
+
+        if (slice.length > 0) {
+          return {
+            games: slice,
+            basedOn: basedOnNames,
+            hasMore
+          };
+        }
+      }
+    } catch (err) {
+      console.warn('[IgdbProvider] Error getting personalized discover games:', err);
+    }
+
+    const fallback = this.getFallbackGames();
+    return {
+      games: fallback.slice(offset, offset + limit),
+      basedOn: [],
+      hasMore: offset + limit < fallback.length
+    };
+  }
+
+  async getUpcomingGames(limit = 6): Promise<IgdbGame[]> {
+    const upcomingFallbacks: IgdbGame[] = [
+      {
+        id: 119171,
+        name: 'Grand Theft Auto VI',
+        slug: 'grand-theft-auto-vi',
+        summary:
+          'Grand Theft Auto VI heads to the state of Leonida, home to the neon-soaked streets of Vice City and beyond in the biggest, most immersive evolution of the Grand Theft Auto series yet.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co7v2e.webp',
+        genres: ['Action', 'Adventure', 'Shooter'],
+        platforms: ['PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2025'
+      },
+      {
+        id: 279555,
+        name: 'Monster Hunter Wilds',
+        slug: 'monster-hunter-wilds',
+        summary:
+          'The next generation in the Monster Hunter series. Experience seamless gameplay and dynamic living ecosystems.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co8352.webp',
+        genres: ['Action', 'Role-playing (RPG)', 'Adventure'],
+        platforms: ['PC (Microsoft Windows)', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2025'
+      },
+      {
+        id: 301294,
+        name: 'DOOM: The Dark Ages',
+        slug: 'doom-the-dark-ages',
+        summary:
+          'The prequel to the critically acclaimed DOOM (2016) and DOOM Eternal. Witness the origin of the Doom Slayer rage.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co8g92.webp',
+        genres: ['Shooter', 'Action'],
+        platforms: ['PC (Microsoft Windows)', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2025'
+      },
+      {
+        id: 228498,
+        name: 'Death Stranding 2: On The Beach',
+        slug: 'death-stranding-2-on-the-beach',
+        summary:
+          'Embark on an inspiring mission of human connection beyond the UCA. Sam with companions sets out on a new journey to save humanity from extinction.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co7rqp.webp',
+        genres: ['Action', 'Adventure'],
+        platforms: ['PlayStation 5'],
+        releaseYear: '2025'
+      }
+    ];
+
+    const token = await this.getAccessToken();
+    if (!token || !this.clientId) {
+      return upcomingFallbacks.slice(0, limit);
+    }
+
+    try {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const fetchLimit = Math.max(limit * 3, 20);
+      const body = `
+        fields name, slug, summary, storyline, category, cover.image_id, cover.url,
+               artworks.image_id, artworks.url, screenshots.image_id, screenshots.url,
+               genres.name, platforms.name, platforms.abbreviation, game_modes.name,
+               first_release_date, hypes, rating,
+               involved_companies.developer, involved_companies.publisher, involved_companies.company.name;
+        where first_release_date > ${nowSeconds} & cover != null & category = (0, 8, 9);
+        sort hypes desc;
+        limit ${fetchLimit};
+      `;
+
+      const res = await fetch('https://api.igdb.com/v4/games', {
+        method: 'POST',
+        headers: {
+          'Client-ID': this.clientId,
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'text/plain'
+        },
+        body
+      });
+
+      if (!res.ok) {
+        return upcomingFallbacks.slice(0, limit);
+      }
+
+      const rawGames = (await res.json()) as IgdbRawGame[];
+      const filtered = rawGames
+        .map((g) => this.transformGame(g))
+        .filter((g) => !this.isDlcOrExpansion(g.name, g.slug, g.category));
+
+      if (filtered.length < limit) {
+        for (const f of upcomingFallbacks) {
+          if (!filtered.some((x) => x.slug === f.slug)) {
+            filtered.push(f);
+          }
+        }
+      }
+
+      return filtered.slice(0, limit);
+    } catch {
+      return upcomingFallbacks.slice(0, limit);
+    }
+  }
+
+  private getFallbackGames(): IgdbGame[] {
+    return [
+      {
+        id: 119133,
+        name: 'Elden Ring',
+        slug: 'elden-ring',
+        summary:
+          'THE NEW FANTASY ACTION RPG. Rise, Tarnished, and be guided by grace to brandish the power of the Elden Ring and become an Elden Lord in the Lands Between.',
+        storyline:
+          'In the Lands Between ruled by Queen Marika the Eternal, the Elden Ring, the source of the Erdtree, has been shattered.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co4jni.webp',
+        bannerUrl: 'https://images.igdb.com/igdb/image/upload/t_1080p/sc7xvd.webp',
+        genres: ['Role-playing (RPG)', 'Adventure'],
+        platforms: [
+          'PC (Microsoft Windows)',
+          'PlayStation 5',
+          'Xbox Series X|S',
+          'PlayStation 4',
+          'Xbox One'
+        ],
+        releaseYear: '2022',
+        developer: 'FromSoftware',
+        publisher: 'Bandai Namco Entertainment',
+        rating: 4.9
+      },
+      {
+        id: 125174,
+        name: "Baldur's Gate 3",
+        slug: 'baldurs-gate-3',
+        summary:
+          "An ancient evil has returned to Baldur's Gate, intent on devouring it from the inside out. The fate of the Forgotten Realms lies in your hands.",
+        storyline:
+          'Abducted, infected, lost. You are turning into a monster, but as the corruption inside you grows, so does your power.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co670h.webp',
+        bannerUrl: 'https://images.igdb.com/igdb/image/upload/t_1080p/sc8d7z.webp',
+        genres: ['Role-playing (RPG)', 'Strategy', 'Tactical', 'Turn-based strategy (TBS)'],
+        platforms: ['PC (Microsoft Windows)', 'PlayStation 5', 'Xbox Series X|S', 'Mac'],
+        releaseYear: '2023',
+        developer: 'Larian Studios',
+        publisher: 'Larian Studios',
+        rating: 4.9
+      },
+      {
+        id: 1877,
+        name: 'Cyberpunk 2077',
+        slug: 'cyberpunk-2077',
+        summary:
+          'Cyberpunk 2077 is an open-world, action-adventure RPG set in the megalopolis of Night City, where you play as a cyberpunk mercenary wrapped up in a do-or-die fight for survival.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co8v0m.webp',
+        bannerUrl: 'https://images.igdb.com/igdb/image/upload/t_1080p/sc7t6y.webp',
+        genres: ['Role-playing (RPG)', 'Shooter', 'Adventure'],
+        platforms: ['PC (Microsoft Windows)', 'PlayStation 5', 'Xbox Series X|S'],
+        releaseYear: '2020',
+        developer: 'CD Projekt RED',
+        publisher: 'CD Projekt',
+        rating: 4.4
+      },
+      {
+        id: 119277,
+        name: 'The Legend of Zelda: Tears of the Kingdom',
+        slug: 'the-legend-of-zelda-tears-of-the-kingdom',
+        summary:
+          'An epic adventure across the land and skies of Hyrule awaits in The Legend of Zelda: Tears of the Kingdom for Nintendo Switch.',
+        coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co5vmg.webp',
+        bannerUrl: 'https://images.igdb.com/igdb/image/upload/t_1080p/sc8x8s.webp',
+        genres: ['Adventure'],
+        platforms: ['Nintendo Switch'],
+        releaseYear: '2023',
+        developer: 'Nintendo EPD',
+        publisher: 'Nintendo',
+        rating: 4.8
+      }
+    ];
+  }
+}
+
+export const igdbProvider = new IgdbProvider();

--- a/apps/web/src/app/games/games-explorer-view.tsx
+++ b/apps/web/src/app/games/games-explorer-view.tsx
@@ -1,0 +1,927 @@
+'use client';
+
+import {
+  Check,
+  ChevronDown,
+  Gamepad2,
+  Loader2,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+  Star,
+  X
+} from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Footer } from '@/components/navigation/footer';
+import { TopNav } from '@/components/navigation/top-nav';
+import { FadeDots } from '@/components/ui/fade-dots';
+import { PosterImage } from '@/components/ui/poster-image';
+import {
+  type Game,
+  getDiscoverGames,
+  getPopularGames,
+  getPopularNewReleases,
+  getTopRatedGames,
+  searchGames
+} from '@/lib/games';
+
+interface GamesExplorerViewProps {
+  initialPopularGames: Game[];
+  initialTopRatedGames?: Game[];
+  initialUpcomingGames?: Game[];
+  initialDiscoverGames?: Game[];
+}
+
+const TAB_CONFIG: Record<string, { title: string; subtitle: string; badge: string }> = {
+  descobrir: {
+    title: 'Descubra',
+    subtitle: 'Explore títulos personalizados de acordo com seus jogos favoritos e estilo de jogo.',
+    badge: 'Resultados inteligentes baseados no que você jogou'
+  },
+  populares: {
+    title: 'Populares',
+    subtitle: 'Confira os jogos que estão conquistando o público e dominando as listas.',
+    badge: 'Mais populares de todos os tempos'
+  },
+  'bem-avaliados': {
+    title: 'Bem avaliados',
+    subtitle:
+      'Explore os títulos mais aclamados, com as melhores avaliações do público e da crítica.',
+    badge: 'Melhores notas pela crítica e jogadores'
+  },
+  lancamentos: {
+    title: 'Lançamentos',
+    subtitle:
+      'Confira os lançamentos mais populares e recentes do Steam, com capas e dados sincronizados.',
+    badge: 'Lançamentos Populares no Steam'
+  }
+};
+
+const GENRES = [
+  'Todos',
+  'Ação',
+  'RPG',
+  'Aventura',
+  'Tiro',
+  'Estratégia',
+  'Esportes',
+  'Indie',
+  'Simulador'
+];
+
+const PLATFORMS = ['Todas', 'PC', 'PlayStation', 'Xbox', 'Nintendo Switch'];
+const MODES = ['Todos', 'Single player', 'Multiplayer'];
+
+interface FilterSelectProps {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (value: string) => void;
+}
+
+function FilterSelect({ label, value, options, onChange }: FilterSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [isOpen]);
+
+  return (
+    <div ref={containerRef} className={`relative space-y-1 ${isOpen ? 'z-30' : 'z-10'}`}>
+      <span className="font-medium text-[11px] text-neutral-400">{label}</span>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+        className={`flex h-9.5 w-full items-center justify-between rounded-xl border px-3 text-left text-xs transition-all duration-200 ${
+          isOpen
+            ? 'border-white/25 bg-white/[0.09] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_0_0_3px_rgba(255,255,255,0.04)]'
+            : 'border-white/[0.08] bg-white/[0.04] text-neutral-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] hover:border-white/[0.16] hover:bg-white/[0.07]'
+        }`}
+      >
+        <span className="truncate">{value}</span>
+        <motion.span animate={{ rotate: isOpen ? 180 : 0 }} transition={{ duration: 0.2 }}>
+          <ChevronDown className="size-3.5 text-neutral-400" />
+        </motion.span>
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            role="listbox"
+            initial={{ opacity: 0, y: -4, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -4, scale: 0.98 }}
+            transition={{ duration: 0.15, ease: 'easeOut' }}
+            className="absolute top-full right-0 left-0 z-30 mt-1 max-h-48 overflow-y-auto rounded-xl bg-[#161616]/90 p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.15),0_18px_36px_rgba(0,0,0,0.8)] backdrop-blur-2xl"
+          >
+            {options.map((option) => (
+              <button
+                key={option}
+                type="button"
+                role="option"
+                aria-selected={option === value}
+                onClick={() => {
+                  onChange(option);
+                  setIsOpen(false);
+                }}
+                className={`flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-left text-xs transition-colors ${
+                  option === value
+                    ? 'bg-white font-medium text-black shadow-sm'
+                    : 'text-neutral-300 hover:bg-white/[0.08] hover:text-white'
+                }`}
+              >
+                <span>{option}</span>
+                {option === value && <Check className="size-3.5" />}
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+/**
+ * Extracts played game slugs from local storage (reviews, collection status, played list).
+ */
+function getStoredPlayedSlugs(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const playedSet = new Set<string>();
+
+    // 1. Array in joysticked_played_games
+    const raw = localStorage.getItem('joysticked_played_games');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        for (const s of parsed) {
+          if (typeof s === 'string') playedSet.add(s.toLowerCase().trim());
+        }
+      }
+    }
+
+    // 2. Scan keys for local_reviews_* and game_status_*
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+
+      if (key.startsWith('local_reviews_')) {
+        const slug = key.replace('local_reviews_', '').trim();
+        if (slug) playedSet.add(slug.toLowerCase());
+      } else if (key.startsWith('game_status_')) {
+        const status = localStorage.getItem(key);
+        if (status === 'Jogado' || status === 'Jogando') {
+          const slug = key.replace('game_status_', '').trim();
+          if (slug) playedSet.add(slug.toLowerCase());
+        }
+      }
+    }
+
+    return Array.from(playedSet);
+  } catch {
+    return [];
+  }
+}
+
+function ExplorerContent({
+  initialPopularGames,
+  initialTopRatedGames = [],
+  initialUpcomingGames = [],
+  initialDiscoverGames = []
+}: GamesExplorerViewProps) {
+  const searchParams = useSearchParams();
+  const rawTab = searchParams.get('tab') || 'descobrir';
+  const tab = TAB_CONFIG[rawTab] ? rawTab : 'descobrir';
+  const config = TAB_CONFIG[tab];
+
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Game[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+  const [selectedGenre, setSelectedGenre] = useState('Todos');
+  const [selectedPlatform, setSelectedPlatform] = useState('Todas');
+  const [minimumScore, setMinimumScore] = useState(0);
+  const [selectedMode, setSelectedMode] = useState('Todos');
+
+  const filterPopoverRef = useRef<HTMLDivElement | null>(null);
+
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (query.trim()) count++;
+    if (selectedGenre !== 'Todos') count++;
+    if (selectedPlatform !== 'Todas') count++;
+    if (minimumScore > 0) count++;
+    if (selectedMode !== 'Todos') count++;
+    return count;
+  }, [query, selectedGenre, selectedPlatform, minimumScore, selectedMode]);
+
+  useEffect(() => {
+    if (!showFilters) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setShowFilters(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [showFilters]);
+
+  // Dynamic paginated list for the active tab
+  const [gamesList, setGamesList] = useState<Game[]>(() => {
+    if (tab === 'descobrir') {
+      return initialDiscoverGames.length > 0 ? initialDiscoverGames : initialPopularGames;
+    }
+    if (tab === 'bem-avaliados') {
+      return initialTopRatedGames.length > 0 ? initialTopRatedGames : initialPopularGames;
+    }
+    if (tab === 'lancamentos') {
+      return initialUpcomingGames.length > 0 ? initialUpcomingGames : initialPopularGames;
+    }
+    return initialPopularGames;
+  });
+
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [basedOnTitles, setBasedOnTitles] = useState<string[]>([]);
+  const [isPersonalizing, setIsPersonalizing] = useState(false);
+
+  // Sentinel ref for infinite scroll
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Debounced live search
+  useEffect(() => {
+    if (!query.trim()) {
+      setSearchResults([]);
+      setIsSearching(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsSearching(true);
+      searchGames(query.trim())
+        .then((games) => setSearchResults(games))
+        .catch(() => setSearchResults([]))
+        .finally(() => setIsSearching(false));
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  // Reset or personalize gamesList whenever tab changes or on mount
+  useEffect(() => {
+    setHasMore(true);
+    setIsLoadingMore(false);
+
+    if (tab === 'descobrir') {
+      const played = getStoredPlayedSlugs();
+      if (played.length > 0) {
+        setIsPersonalizing(true);
+        getDiscoverGames({ played, limit: 21, offset: 0 })
+          .then((res) => {
+            if (res.games.length > 0) {
+              // Ensure we display at least 21 titles: if personalized has less than 21, supplement from initial games
+              const combined = [...res.games];
+              if (combined.length < 21) {
+                const pool =
+                  initialDiscoverGames.length > 0 ? initialDiscoverGames : initialPopularGames;
+                for (const g of pool) {
+                  if (!combined.some((item) => (item.id || item.slug) === (g.id || g.slug))) {
+                    combined.push(g);
+                    if (combined.length >= 21) break;
+                  }
+                }
+              }
+              setGamesList(combined);
+              setBasedOnTitles(res.basedOn);
+              setHasMore(res.hasMore);
+            } else {
+              setGamesList(
+                initialDiscoverGames.length > 0 ? initialDiscoverGames : initialPopularGames
+              );
+            }
+          })
+          .catch(() => {
+            setGamesList(
+              initialDiscoverGames.length > 0 ? initialDiscoverGames : initialPopularGames
+            );
+          })
+          .finally(() => setIsPersonalizing(false));
+      } else {
+        setGamesList(initialDiscoverGames.length > 0 ? initialDiscoverGames : initialPopularGames);
+        setBasedOnTitles([]);
+      }
+    } else if (tab === 'bem-avaliados') {
+      setGamesList(initialTopRatedGames.length > 0 ? initialTopRatedGames : initialPopularGames);
+      setBasedOnTitles([]);
+    } else if (tab === 'lancamentos') {
+      setGamesList(initialUpcomingGames.length > 0 ? initialUpcomingGames : initialPopularGames);
+      setBasedOnTitles([]);
+    } else {
+      setGamesList(initialPopularGames);
+      setBasedOnTitles([]);
+    }
+  }, [tab, initialDiscoverGames, initialPopularGames, initialTopRatedGames, initialUpcomingGames]);
+
+  // Infinite Scroll fetcher (loads in batches of 21 titles)
+  const loadMoreGames = useCallback(async () => {
+    if (
+      isLoadingMore ||
+      !hasMore ||
+      query.trim() ||
+      selectedGenre !== 'Todos' ||
+      selectedPlatform !== 'Todas' ||
+      minimumScore > 0 ||
+      selectedMode !== 'Todos' ||
+      gamesList.length < 21
+    )
+      return;
+
+    setIsLoadingMore(true);
+    const currentOffset = gamesList.length;
+
+    try {
+      if (tab === 'descobrir') {
+        const played = getStoredPlayedSlugs();
+        const res = await getDiscoverGames({
+          played,
+          limit: 21,
+          offset: currentOffset
+        });
+
+        if (res.games.length > 0) {
+          setGamesList((prev) => {
+            const existingKeys = new Set(prev.map((g) => `${g.id || ''}-${g.slug}`));
+            const unique = res.games.filter((g) => !existingKeys.has(`${g.id || ''}-${g.slug}`));
+            return [...prev, ...unique];
+          });
+          setHasMore(res.hasMore && res.games.length >= 7);
+        } else {
+          setHasMore(false);
+        }
+      } else if (tab === 'populares') {
+        const newGames = await getPopularGames(21, currentOffset);
+        if (newGames.length > 0) {
+          setGamesList((prev) => {
+            const existingKeys = new Set(prev.map((g) => `${g.id || ''}-${g.slug}`));
+            const unique = newGames.filter((g) => !existingKeys.has(`${g.id || ''}-${g.slug}`));
+            return [...prev, ...unique];
+          });
+          setHasMore(newGames.length >= 21);
+        } else {
+          setHasMore(false);
+        }
+      } else if (tab === 'bem-avaliados') {
+        const newGames = await getTopRatedGames(21, currentOffset);
+        if (newGames.length > 0) {
+          setGamesList((prev) => {
+            const existingKeys = new Set(prev.map((g) => `${g.id || ''}-${g.slug}`));
+            const unique = newGames.filter((g) => !existingKeys.has(`${g.id || ''}-${g.slug}`));
+            return [...prev, ...unique];
+          });
+          setHasMore(newGames.length >= 21);
+        } else {
+          setHasMore(false);
+        }
+      } else if (tab === 'lancamentos') {
+        const newGames = await getPopularNewReleases(21, currentOffset);
+        if (newGames.length > 0) {
+          setGamesList((prev) => {
+            const existingKeys = new Set(prev.map((g) => `${g.id || ''}-${g.slug}`));
+            const unique = newGames.filter((g) => !existingKeys.has(`${g.id || ''}-${g.slug}`));
+            return [...prev, ...unique];
+          });
+          setHasMore(newGames.length >= 21);
+        } else {
+          setHasMore(false);
+        }
+      }
+    } catch (err) {
+      console.warn('Error loading more games on scroll:', err);
+      setHasMore(false);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [
+    isLoadingMore,
+    hasMore,
+    query,
+    selectedGenre,
+    selectedPlatform,
+    minimumScore,
+    selectedMode,
+    gamesList.length,
+    tab
+  ]);
+
+  // Observer on Sentinel
+  useEffect(() => {
+    if (
+      !hasMore ||
+      isLoadingMore ||
+      query.trim() ||
+      selectedGenre !== 'Todos' ||
+      selectedPlatform !== 'Todas' ||
+      minimumScore > 0 ||
+      selectedMode !== 'Todos' ||
+      gamesList.length < 21
+    )
+      return;
+
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadMoreGames();
+        }
+      },
+      { rootMargin: '100px' } // Only triggers when user scrolls near the bottom of 21 titles
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [
+    hasMore,
+    isLoadingMore,
+    query,
+    selectedGenre,
+    selectedPlatform,
+    minimumScore,
+    selectedMode,
+    loadMoreGames,
+    gamesList.length
+  ]);
+
+  // Apply search and genre filter
+  const displayGames = useMemo(() => {
+    let list = query.trim() ? searchResults : gamesList;
+
+    if (selectedGenre !== 'Todos') {
+      const genreLower = selectedGenre.toLowerCase();
+      list = list.filter((g) =>
+        (g.genres || []).some((genre) => genre.toLowerCase().includes(genreLower))
+      );
+    }
+
+    if (selectedPlatform !== 'Todas') {
+      const platformLower = selectedPlatform.toLowerCase();
+      list = list.filter((g) =>
+        (g.platforms || []).some((platform) => platform.toLowerCase().includes(platformLower))
+      );
+    }
+
+    if (minimumScore > 0) {
+      list = list.filter((g) => Number(g.rating || 0) >= minimumScore);
+    }
+
+    if (selectedMode !== 'Todos') {
+      const modeLower = selectedMode.toLowerCase();
+      list = list.filter((g) =>
+        (g.gameModes || []).some((mode) => mode.toLowerCase().includes(modeLower))
+      );
+    }
+
+    return list;
+  }, [
+    query,
+    searchResults,
+    gamesList,
+    selectedGenre,
+    selectedPlatform,
+    minimumScore,
+    selectedMode
+  ]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-950 text-neutral-100 selection:bg-white/20 selection:text-white">
+      {/* Centralized Floating Capsule Bar */}
+      <TopNav />
+
+      {/* Main Container */}
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 pt-24 pb-24 sm:px-6 sm:pt-28 md:px-8">
+        {/* Header */}
+        <header className="mb-6 space-y-3 sm:mb-8">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2.5">
+                <h1 className="font-bold font-redaction text-2xl text-white tracking-tight sm:text-4xl md:text-5xl">
+                  {config.title}
+                </h1>
+                {isPersonalizing && (
+                  <div className="inline-flex animate-pulse items-center gap-1 rounded-full bg-amber-400/10 px-2.5 py-0.5 text-[11px] text-amber-400/80">
+                    <Sparkles className="size-3" />
+                    <span>Calibrando...</span>
+                  </div>
+                )}
+              </div>
+              <p className="mt-1 max-w-2xl text-neutral-400 text-xs leading-relaxed sm:text-sm">
+                {config.subtitle}
+              </p>
+            </div>
+
+            {/* Filter Toggle Button & Anchored Popover */}
+            <div className="relative z-30" ref={filterPopoverRef}>
+              <button
+                type="button"
+                onClick={() => setShowFilters((prev) => !prev)}
+                aria-expanded={showFilters}
+                aria-controls="games-filter-popover"
+                className={`relative flex size-10 select-none items-center justify-center rounded-xl border transition-all active:scale-[0.96] ${
+                  showFilters
+                    ? 'border-white/30 bg-white text-black shadow-[inset_0_1px_0_rgba(255,255,255,0.5),0_8px_24px_rgba(255,255,255,0.15)]'
+                    : 'border-white/[0.08] bg-white/[0.04] text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-md hover:border-white/[0.18] hover:bg-white/[0.08] hover:text-white'
+                }`}
+                title="Filtrar jogos"
+              >
+                <SlidersHorizontal className="size-4.5" />
+                {activeFilterCount > 0 && (
+                  <span className="-top-1 -right-1 absolute flex size-4 items-center justify-center rounded-full bg-white font-bold text-[10px] text-black ring-2 ring-[#0a0a0a]">
+                    {activeFilterCount}
+                  </span>
+                )}
+              </button>
+
+              <AnimatePresence>
+                {showFilters && (
+                  <>
+                    {/* Backdrop to capture outside clicks */}
+                    <div
+                      className="fixed inset-0 z-40 bg-black/25 backdrop-blur-[1.5px]"
+                      onClick={() => setShowFilters(false)}
+                      aria-hidden="true"
+                    />
+
+                    {/* Popover pulled directly from the filter button */}
+                    <motion.div
+                      id="games-filter-popover"
+                      initial={{ opacity: 0, y: -6, scale: 0.98 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      exit={{ opacity: 0, y: -4, scale: 0.98 }}
+                      transition={{ duration: 0.16, ease: [0.2, 0, 0, 1] }}
+                      className="absolute top-full right-0 z-50 mt-2.5 flex w-[330px] max-w-[calc(100vw-2rem)] origin-top-right flex-col overflow-hidden rounded-2xl bg-[#121212]/80 p-4 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.16),inset_0_0_0_1px_rgba(255,255,255,0.04),0_24px_60px_rgba(0,0,0,0.85)] backdrop-blur-2xl backdrop-saturate-150 sm:w-[360px]"
+                    >
+                      {/* Subtle liquid glass sheen overlay */}
+                      <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-b from-white/[0.07] via-transparent to-transparent" />
+
+                      <div className="relative mb-3 flex items-center justify-between border-white/[0.08] border-b pb-3">
+                        <div className="flex items-center gap-2">
+                          <SlidersHorizontal className="size-4 text-neutral-400" />
+                          <span className="font-semibold text-white text-xs">Filtros</span>
+                          {activeFilterCount > 0 && (
+                            <span className="rounded-full border border-white/10 bg-white/[0.08] px-1.5 py-0.5 font-medium text-[10px] text-neutral-200">
+                              {activeFilterCount}
+                            </span>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setShowFilters(false)}
+                          aria-label="Fechar filtros"
+                          className="flex size-7 items-center justify-center rounded-lg text-neutral-400 transition-colors hover:bg-white/[0.08] hover:text-white"
+                        >
+                          <X className="size-3.5" />
+                        </button>
+                      </div>
+
+                      <div className="relative max-h-[min(68vh,520px)] space-y-3.5 overflow-y-auto pr-0.5">
+                        <div className="relative flex items-center">
+                          <Search className="pointer-events-none absolute left-3 size-3.5 text-neutral-500" />
+                          <input
+                            type="search"
+                            value={query}
+                            onChange={(event) => setQuery(event.target.value)}
+                            placeholder="Buscar pelo título exato..."
+                            className="h-9.5 w-full rounded-xl border border-white/[0.08] bg-white/[0.04] pr-8 pl-8 text-white text-xs shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] outline-none transition-all placeholder:text-neutral-500 hover:border-white/[0.16] hover:bg-white/[0.06] focus:border-white/25 focus:bg-white/[0.07] focus:shadow-[0_0_0_3px_rgba(255,255,255,0.04)]"
+                          />
+                          {query && (
+                            <button
+                              type="button"
+                              onClick={() => setQuery('')}
+                              aria-label="Limpar busca"
+                              className="absolute right-2.5 text-neutral-500 transition-colors hover:text-white"
+                            >
+                              <X className="size-3" />
+                            </button>
+                          )}
+                        </div>
+
+                        <FilterSelect
+                          label="Gênero"
+                          value={selectedGenre}
+                          options={GENRES}
+                          onChange={setSelectedGenre}
+                        />
+                        <FilterSelect
+                          label="Plataforma"
+                          value={selectedPlatform}
+                          options={PLATFORMS}
+                          onChange={setSelectedPlatform}
+                        />
+
+                        <div className="space-y-1.5 rounded-xl border border-white/[0.08] bg-white/[0.03] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+                          <div className="flex items-center justify-between">
+                            <label
+                              htmlFor="minimum-score"
+                              className="font-medium text-[11px] text-neutral-400"
+                            >
+                              Nota mínima
+                            </label>
+                            <output
+                              htmlFor="minimum-score"
+                              className="rounded-md border border-white/10 bg-white/[0.08] px-1.5 py-0.5 font-semibold text-[10px] text-white"
+                            >
+                              {minimumScore === 0 ? 'Todas' : `${minimumScore.toFixed(1)}+`}
+                            </output>
+                          </div>
+                          <div className="relative px-1 pt-2">
+                            <input
+                              id="minimum-score"
+                              type="range"
+                              min="0"
+                              max="5"
+                              step="0.5"
+                              value={minimumScore}
+                              onChange={(event) => setMinimumScore(Number(event.target.value))}
+                              className="relative z-10 h-1.5 w-full cursor-pointer accent-white"
+                            />
+                            <div className="mt-1.5 flex justify-between text-[9px] text-neutral-500">
+                              {Array.from({ length: 11 }, (_, index) => {
+                                const score = index / 2;
+                                return (
+                                  <span
+                                    key={score}
+                                    className={
+                                      minimumScore === score ? 'font-semibold text-white' : ''
+                                    }
+                                  >
+                                    {score % 1 === 0 ? score : score.toFixed(1)}
+                                  </span>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        </div>
+
+                        <FilterSelect
+                          label="Modo de jogo"
+                          value={selectedMode}
+                          options={MODES}
+                          onChange={setSelectedMode}
+                        />
+                      </div>
+
+                      <div className="relative mt-3 grid grid-cols-2 gap-2 border-white/[0.08] border-t pt-3">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setQuery('');
+                            setSelectedGenre('Todos');
+                            setSelectedPlatform('Todas');
+                            setMinimumScore(0);
+                            setSelectedMode('Todos');
+                          }}
+                          className="h-9 rounded-xl border border-white/[0.09] bg-white/[0.03] text-neutral-300 text-xs transition-colors hover:border-white/[0.16] hover:bg-white/[0.08] hover:text-white"
+                        >
+                          Limpar tudo
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setShowFilters(false)}
+                          className="h-9 rounded-xl bg-white font-semibold text-black text-xs shadow-[inset_0_1px_0_rgba(255,255,255,0.4),0_4px_16px_rgba(255,255,255,0.12)] transition-transform hover:bg-neutral-100 active:scale-[0.98]"
+                        >
+                          Ver resultados
+                        </button>
+                      </div>
+                    </motion.div>
+                  </>
+                )}
+              </AnimatePresence>
+            </div>
+          </div>
+
+          {/* Subtitle Badge Pill & Personalization Info */}
+          <div className="flex flex-wrap items-center gap-2">
+            {tab === 'descobrir' && basedOnTitles.length > 0 ? (
+              <motion.div
+                initial={{ opacity: 0, scale: 0.96 }}
+                animate={{ opacity: 1, scale: 1 }}
+                className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/25 bg-amber-500/10 px-3 py-1 font-medium text-[11.5px] text-amber-300 shadow-sm"
+              >
+                <Sparkles className="size-3 text-amber-400" />
+                <span>
+                  Baseado no que você jogou:{' '}
+                  <strong className="font-semibold text-white">
+                    {basedOnTitles.slice(0, 3).join(', ')}
+                  </strong>
+                </span>
+              </motion.div>
+            ) : (
+              <span className="inline-flex select-none items-center gap-1.5 rounded-full border border-white/[0.06] bg-white/[0.04] px-3 py-1 font-medium text-[11px] text-neutral-300">
+                <Sparkles className="size-3 text-amber-400" />
+                <span>{config.badge}</span>
+              </span>
+            )}
+
+            {selectedGenre !== 'Todos' && (
+              <button
+                type="button"
+                onClick={() => setSelectedGenre('Todos')}
+                className="inline-flex items-center gap-1 rounded-full bg-white/[0.08] px-2.5 py-0.5 text-[10.5px] text-white transition-colors hover:bg-white/[0.12]"
+              >
+                <span>{selectedGenre}</span>
+                <X className="size-3 text-neutral-400" />
+              </button>
+            )}
+
+            {selectedPlatform !== 'Todas' && (
+              <button
+                type="button"
+                onClick={() => setSelectedPlatform('Todas')}
+                className="inline-flex items-center gap-1 rounded-full bg-white/[0.08] px-2.5 py-0.5 text-[10.5px] text-white transition-colors hover:bg-white/[0.12]"
+              >
+                <span>{selectedPlatform}</span>
+                <X className="size-3 text-neutral-400" />
+              </button>
+            )}
+
+            {minimumScore > 0 && (
+              <button
+                type="button"
+                onClick={() => setMinimumScore(0)}
+                className="inline-flex items-center gap-1 rounded-full bg-white/[0.08] px-2.5 py-0.5 text-[10.5px] text-white transition-colors hover:bg-white/[0.12]"
+              >
+                <span>Nota {minimumScore.toFixed(1)}+</span>
+                <X className="size-3 text-neutral-400" />
+              </button>
+            )}
+
+            {selectedMode !== 'Todos' && (
+              <button
+                type="button"
+                onClick={() => setSelectedMode('Todos')}
+                className="inline-flex items-center gap-1 rounded-full bg-white/[0.08] px-2.5 py-0.5 text-[10.5px] text-white transition-colors hover:bg-white/[0.12]"
+              >
+                <span>{selectedMode}</span>
+                <X className="size-3 text-neutral-400" />
+              </button>
+            )}
+          </div>
+        </header>
+
+        {/* Compact & High-Density Poster Grid */}
+        {displayGames.length === 0 && !isSearching ? (
+          <div className="space-y-3 rounded-2xl border border-white/[0.04] bg-neutral-900/30 p-16 text-center">
+            <Gamepad2 className="mx-auto size-10 text-neutral-600" />
+            <p className="font-semibold text-neutral-300 text-sm">Nenhum título encontrado</p>
+            <p className="text-neutral-500 text-xs">
+              Tente redefinir os filtros ou buscar por outro termo.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                setSelectedGenre('Todos');
+                setSelectedPlatform('Todas');
+                setMinimumScore(0);
+                setSelectedMode('Todos');
+              }}
+              className="pt-1 text-white text-xs underline underline-offset-4"
+            >
+              Limpar filtros
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-4 sm:gap-3 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7">
+            {displayGames.map((game, idx) => (
+              <motion.div
+                key={`${game.id || game.slug}-${idx}`}
+                whileHover={{ y: -5, scale: 1.025 }}
+                whileTap={{ scale: 0.98 }}
+                transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+              >
+                <Link
+                  href={`/games/${game.slug}`}
+                  className="group relative block aspect-[2/3] cursor-pointer overflow-hidden rounded-xl border border-white/[0.04] bg-neutral-900 shadow-md transition-all hover:border-white/20 hover:shadow-[0_12px_28px_rgba(0,0,0,0.8)]"
+                >
+                  {/* Poster Cover Image with Smooth Skeleton Shimmer */}
+                  <PosterImage src={game.coverUrl} alt={game.name} />
+
+                  {/* Rating / Steam Awaited / Steam New Release Badge */}
+                  {game.isSteamNewRelease ? (
+                    <div className="absolute top-1.5 right-1.5 flex items-center gap-0.5 rounded-md border border-emerald-500/30 bg-black/85 px-1.5 py-0.5 font-bold text-[8.5px] text-emerald-400 shadow backdrop-blur-md">
+                      <Sparkles className="size-2" />
+                      <span>Steam</span>
+                    </div>
+                  ) : game.isSteamAwaited ? (
+                    <div className="absolute top-1.5 right-1.5 flex items-center gap-0.5 rounded-md border border-amber-500/30 bg-black/85 px-1.5 py-0.5 font-bold text-[8.5px] text-amber-400 shadow backdrop-blur-md">
+                      <Sparkles className="size-2" />
+                      <span>Aguardado</span>
+                    </div>
+                  ) : game.rating ? (
+                    <div className="absolute top-1.5 right-1.5 flex items-center gap-0.5 rounded-md bg-black/75 px-1.5 py-0.5 font-bold text-[9px] text-amber-300 shadow backdrop-blur-md">
+                      <Star className="size-2 fill-amber-300 text-amber-300" />
+                      <span>{game.rating.toFixed(1)}</span>
+                    </div>
+                  ) : game.releaseYear ? (
+                    <div className="absolute top-1.5 right-1.5 rounded-md bg-black/75 px-1.5 py-0.5 font-semibold text-[8.5px] text-neutral-300 backdrop-blur-md">
+                      {game.releaseYear}
+                    </div>
+                  ) : null}
+
+                  {/* Bottom Dark Gradient with Game Title */}
+                  <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/90 via-black/25 to-transparent p-2.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                    <span className="line-clamp-2 font-semibold text-[11px] text-white leading-tight">
+                      {game.name}
+                    </span>
+                    {game.genres?.[0] && (
+                      <span className="mt-0.5 truncate text-[9px] text-neutral-400">
+                        {game.genres[0]}
+                      </span>
+                    )}
+                  </div>
+                </Link>
+              </motion.div>
+            ))}
+          </div>
+        )}
+
+        {/* Sentinel & Infinite Scroll Loader */}
+        <div
+          ref={sentinelRef}
+          className="flex w-full flex-col items-center justify-center gap-2 py-8"
+        >
+          {isLoadingMore && (
+            <div className="flex flex-col items-center gap-2 py-4">
+              <FadeDots />
+              <span className="font-medium text-[11px] text-neutral-500 tracking-wide">
+                Carregando mais opções...
+              </span>
+            </div>
+          )}
+          {!hasMore &&
+            gamesList.length > 0 &&
+            !query.trim() &&
+            selectedGenre === 'Todos' &&
+            selectedPlatform === 'Todas' &&
+            minimumScore === 0 &&
+            selectedMode === 'Todos' && (
+              <p className="font-medium text-[11px] text-neutral-600 tracking-wide">
+                Você chegou ao final dos títulos disponíveis.
+              </p>
+            )}
+        </div>
+      </main>
+
+      {/* Floating Micro-Pill (Bottom Right) */}
+      <div className="fixed right-5 bottom-5 z-40">
+        <Link
+          href="/pro"
+          className="group flex select-none items-center gap-2 rounded-full border border-white/[0.06] bg-neutral-900/90 px-3.5 py-1.5 text-neutral-200 text-xs shadow-2xl backdrop-blur-md transition-all hover:bg-neutral-800 active:scale-95"
+        >
+          <Sparkles className="size-3.5 text-amber-400 transition-transform group-hover:rotate-12" />
+          <span className="font-medium text-[11.5px] sm:text-xs">
+            Ganhe 7 dias grátis do plano PRO
+          </span>
+          <span className="rounded-full bg-gradient-to-r from-amber-500 to-amber-600 px-1.5 py-0.2 font-extrabold text-[9px] text-black uppercase tracking-wider">
+            PRO
+          </span>
+        </Link>
+      </div>
+
+      {/* Global Footer */}
+      <Footer />
+    </div>
+  );
+}
+
+export function GamesExplorerView(props: GamesExplorerViewProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-neutral-950">
+          <Loader2 className="size-6 animate-spin text-neutral-500" />
+        </div>
+      }
+    >
+      <ExplorerContent {...props} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { HomeView } from '@/components/home/home-view';
+import { getHomeFeed } from '@/lib/games';
+
+export const metadata: Metadata = {
+  title: 'Início | Joysticked',
+  description: 'Descubra o que jogar, acompanhe sua biblioteca e compartilhe suas avaliações.'
+};
+
+export default async function HomePage() {
+  const initialData = await getHomeFeed();
+
+  return <HomeView initialData={initialData} />;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,25 +1,122 @@
-'use client';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Footer } from '@/components/navigation/footer';
+import { TopNav } from '@/components/navigation/top-nav';
 
-import { useEffect, useState } from 'react';
-import { useMediaQuery } from 'usehooks-ts';
+export const metadata: Metadata = {
+  title: 'Joysticked — encontre seu próximo jogo',
+  description: 'Descubra jogos, compartilhe suas notas e encontre sua próxima obsessão.'
+};
 
-import { DesktopHero } from '@/components/landing/hero/desktop';
-import { TabletAndMobileHero } from '@/components/landing/hero/tablet-and-mobile';
+const PILLARS = [
+  {
+    number: '01',
+    title: 'Descubra',
+    text: 'Encontre jogos que combinam com o que você gosta — do hype do momento às joias escondidas.',
+    icon: 'discover'
+  },
+  {
+    number: '02',
+    title: 'Avalie',
+    text: 'Registre o que jogou, dê sua nota e escreva uma opinião que realmente ajuda outras pessoas.',
+    icon: 'rate'
+  },
+  {
+    number: '03',
+    title: 'Jogue junto',
+    text: 'Acompanhe o que a comunidade está jogando e transforme sua biblioteca em uma história.',
+    icon: 'together'
+  }
+];
 
-export default function Home() {
-  const [isMuted, setIsMuted] = useState(false);
-
-  const isTabletOrMobile = useMediaQuery('(max-width: 1024px)');
-
-  useEffect(() => {
-    setIsMuted(true);
-  }, []);
-
-  if (!isMuted) return null;
-
-  if (isTabletOrMobile) {
-    return <TabletAndMobileHero />;
+function PixelIcon({ type }: { type: 'discover' | 'rate' | 'together' }) {
+  if (type === 'discover') {
+    return (
+      <svg aria-hidden="true" className="size-10" viewBox="0 0 40 40" fill="none">
+        <path fill="#303030" d="M8 16h4v-4h8v4h8v-4h4v4h4v12h-4v4h-8v-4h-8v4H8z" />
+        <path fill="#fff" d="M12 20h4v-4h4v4h4v4h-4v4h-4v-4h-4zM28 20h4v4h-4z" />
+      </svg>
+    );
   }
 
-  return <DesktopHero />;
+  if (type === 'rate') {
+    return (
+      <svg aria-hidden="true" className="size-10" viewBox="0 0 40 40" fill="none">
+        <path fill="#303030" d="M16 8h8v4h4v4h4v12h-4v4H12v-4H8V16h4v-4h4z" />
+        <path fill="#fff" d="M16 12h8v4h4v4h-4v4h-8v-4h-4v-4h4zM16 28h8v-4h4v4h-4v4h-8z" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg aria-hidden="true" className="size-10" viewBox="0 0 40 40" fill="none">
+      <path fill="#303030" d="M8 12h8V8h8v4h8v4h4v12h-4v4h-8v-4h-8v4H8z" />
+      <path fill="#fff" d="M12 16h8v4h-8zM24 16h4v4h-4zM16 24h8v4h-8z" />
+    </svg>
+  );
+}
+
+export default function WelcomePage() {
+  return (
+    <main className="min-h-screen overflow-hidden bg-[#0A0A0A] text-neutral-100 selection:bg-white/20 selection:text-white">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_50%_12%,rgba(48,48,48,0.45),transparent_34%)]" />
+
+      <TopNav />
+
+      <section className="relative z-10 mx-auto flex min-h-[calc(100vh-84px)] w-full max-w-7xl flex-col items-center justify-center px-5 pt-40 pb-16 text-center sm:px-8 sm:pt-44 lg:pb-24">
+        <div className="flex max-w-3xl flex-col items-center">
+          <p className="mb-5 flex items-center gap-2 font-medium text-neutral-400 text-xs uppercase tracking-[0.2em]">
+            <span className="size-1.5 rounded-full bg-[#303030]" />
+            Para quem leva seus jogos a sério
+          </p>
+
+          <h1 className="max-w-3xl font-redaction text-4xl text-white leading-[0.98] tracking-[-0.045em] sm:text-5xl lg:text-6xl">
+            O próximo jogo que vai ficar na sua cabeça.
+          </h1>
+
+          <p className="mt-6 max-w-xl text-base text-neutral-400 leading-relaxed sm:text-lg">
+            Descubra o que jogar, guarde o que marcou você e encontre uma comunidade que entende por
+            que aquele detalhe importa.
+          </p>
+
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Link
+              href="/home"
+              className="inline-flex h-12 items-center justify-center rounded-full bg-white px-6 font-bold text-black text-sm shadow-[0_0_30px_rgba(255,255,255,0.12)] transition-transform hover:scale-[1.02] hover:bg-neutral-200"
+            >
+              Começar a descobrir
+            </Link>
+            <Link
+              href="/games"
+              className="inline-flex h-12 items-center justify-center rounded-full border border-white/15 px-6 font-semibold text-neutral-200 text-sm transition-colors hover:border-white/30 hover:bg-white/[0.06]"
+            >
+              Ver o catálogo
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-12 grid max-w-5xl grid-cols-1 gap-3 border-white/10 border-t pt-5 text-left sm:mt-16 sm:grid-cols-3 sm:gap-8">
+          {PILLARS.map((pillar) => (
+            <div
+              key={pillar.number}
+              className="group border-white/[0.08] last:border-0 sm:border-r sm:pr-7"
+            >
+              <div className="flex items-center gap-3 text-[11px] text-neutral-600 sm:block">
+                <PixelIcon type={pillar.icon} />
+                <span className="font-medium text-neutral-200 text-sm sm:mt-4 sm:block">
+                  {pillar.title}
+                </span>
+              </div>
+              <p className="mt-2 max-w-xs text-neutral-500 text-sm leading-relaxed transition-colors group-hover:text-neutral-300 sm:mt-3">
+                <span className="mr-2 text-[10px] text-neutral-600">{pillar.number}</span>
+                {pillar.text}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  );
 }

--- a/apps/web/src/components/home/home-view.tsx
+++ b/apps/web/src/components/home/home-view.tsx
@@ -1,0 +1,661 @@
+'use client';
+
+import {
+  Award,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Flame,
+  Gamepad2,
+  MessageSquare,
+  Play,
+  Sparkles,
+  Star,
+  TrendingUp
+} from 'lucide-react';
+import { motion } from 'motion/react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { Footer } from '@/components/navigation/footer';
+import { TopNav } from '@/components/navigation/top-nav';
+import { PosterImage } from '@/components/ui/poster-image';
+import type { Game, GameActivity, GameReview, HomeFeedData } from '@/lib/games';
+
+const FALLBACK_POPULAR_GAMES: Game[] = [
+  {
+    id: 3001,
+    name: 'EA SPORTS FC 24',
+    slug: 'ea-sports-fc-24',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co6q78.webp',
+    rating: 3.8
+  },
+  {
+    id: 119133,
+    name: 'Elden Ring',
+    slug: 'elden-ring',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co4jni.webp',
+    rating: 4.8
+  },
+  {
+    id: 1877,
+    name: 'Cyberpunk 2077',
+    slug: 'cyberpunk-2077',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co825v.webp',
+    rating: 4.3
+  }
+];
+
+const FALLBACK_TOP_RATED_GAMES: Game[] = [
+  {
+    id: 1020,
+    name: "Baldur's Gate 3",
+    slug: 'baldurs-gate-3',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co670h.webp',
+    rating: 4.9
+  },
+  {
+    id: 1942,
+    name: 'The Witcher 3: Wild Hunt',
+    slug: 'the-witcher-3-wild-hunt',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1wyy.webp',
+    rating: 4.9
+  },
+  {
+    id: 1192,
+    name: 'Red Dead Redemption 2',
+    slug: 'red-dead-redemption-2',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co1q1f.webp',
+    rating: 4.9
+  }
+];
+
+const FALLBACK_UPCOMING_GAMES: Game[] = [
+  {
+    id: 3219630,
+    name: 'Halloween: The Game',
+    slug: 'halloween-the-game',
+    coverUrl:
+      'https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/3219630/library_600x900.jpg',
+    releaseYear: 'Em breve',
+    isSteamAwaited: true
+  },
+  {
+    id: 1867240,
+    name: 'WARDOGS',
+    slug: 'wardogs',
+    coverUrl:
+      'https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1867240/library_600x900.jpg',
+    releaseYear: 'Em breve',
+    isSteamAwaited: true
+  },
+  {
+    id: 119171,
+    name: 'Grand Theft Auto VI',
+    slug: 'grand-theft-auto-vi',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co7v2e.webp',
+    releaseYear: '2025',
+    isSteamAwaited: true
+  }
+];
+
+const PERIOD_TABS = [
+  { id: 'today', label: 'Hoje' },
+  { id: 'week', label: 'Essa semana' },
+  { id: 'month', label: 'Esse mês' },
+  { id: 'all', label: 'Sempre' }
+] as const;
+
+interface HomeViewProps {
+  initialData?: HomeFeedData | null;
+}
+
+export function HomeView({ initialData }: HomeViewProps) {
+  const [selectedPeriod, setSelectedPeriod] = useState<'today' | 'week' | 'month' | 'all'>('week');
+  const [recentPlayedSlugs, setRecentPlayedSlugs] = useState<string[]>([]);
+
+  // Load client's recently played / reviewed games
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = JSON.parse(localStorage.getItem('joysticked_played_games') || '[]');
+      if (Array.isArray(stored)) {
+        setRecentPlayedSlugs(stored.slice(0, 4));
+      }
+    } catch {}
+  }, []);
+
+  const popularGames =
+    initialData?.popularGames && initialData.popularGames.length > 0
+      ? initialData.popularGames.slice(0, 3)
+      : FALLBACK_POPULAR_GAMES;
+
+  const topRatedGames =
+    initialData?.topRatedGames && initialData.topRatedGames.length > 0
+      ? initialData.topRatedGames.slice(0, 3)
+      : FALLBACK_TOP_RATED_GAMES;
+
+  const upcomingGames =
+    initialData?.upcomingGames && initialData.upcomingGames.length > 0
+      ? initialData.upcomingGames.slice(0, 3)
+      : FALLBACK_UPCOMING_GAMES;
+
+  const reviews: GameReview[] = initialData?.popularReviews || [];
+  const activities: GameActivity[] = initialData?.activities || [];
+
+  const filteredReviews = reviews.filter((review) => {
+    if (selectedPeriod === 'all') return true;
+
+    const createdAt = new Date(review.createdAt);
+    if (Number.isNaN(createdAt.getTime())) return false;
+
+    const now = new Date();
+    let periodStart: Date;
+
+    if (selectedPeriod === 'today') {
+      periodStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    } else if (selectedPeriod === 'week') {
+      const day = now.getDay();
+      const daysSinceMonday = (day + 6) % 7;
+      periodStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysSinceMonday);
+    } else {
+      periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    }
+
+    return createdAt >= periodStart && createdAt <= now;
+  });
+
+  // Spotlight game (featured top-rated title)
+  const spotlightGame = topRatedGames[0] || popularGames[0];
+
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-950 text-neutral-100 selection:bg-white/20 selection:text-white">
+      {/* Centralized Floating Top Navigation */}
+      <TopNav />
+
+      {/* Main Content Area */}
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 pt-20 pb-20 sm:px-6 sm:pt-24 md:px-8">
+        {/* Page Header */}
+        <header className="mb-8 space-y-4">
+          <div>
+            <p className="mb-2 font-semibold text-[11px] text-neutral-500 uppercase tracking-[0.2em]">
+              Seu hub de jogos
+            </p>
+            <h1 className="font-bold text-3xl text-white tracking-tight sm:text-5xl">
+              O que você vai jogar hoje?
+            </h1>
+            <p className="mt-2 max-w-xl text-neutral-400 text-sm leading-relaxed sm:text-base">
+              Encontre seu próximo jogo, acompanhe o que está em alta e deixe sua nota para a
+              comunidade.
+            </p>
+          </div>
+        </header>
+
+        {/* 2-Column Responsive Dashboard */}
+        <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-12 lg:gap-8">
+          {/* LEFT COLUMN: Main Feed (8 cols on lg) */}
+          <section className="space-y-7 lg:col-span-8">
+            {/* Cinematic Spotlight: Destaque do Dia */}
+            {spotlightGame && (
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+                className="group relative overflow-hidden rounded-3xl border border-white/[0.08] bg-neutral-900/80 shadow-2xl backdrop-blur-md"
+              >
+                {/* Background Subtle Artwork Glow */}
+                <div
+                  className="absolute inset-0 bg-center bg-cover opacity-25 blur-xl filter transition-transform duration-700 group-hover:scale-105"
+                  style={{
+                    backgroundImage: `url(${spotlightGame.bannerUrl || spotlightGame.coverUrl})`
+                  }}
+                />
+                <div className="absolute inset-0 bg-gradient-to-r from-neutral-950 via-neutral-950/80 to-transparent" />
+
+                <div className="relative z-10 flex flex-col items-start gap-5 p-6 sm:flex-row sm:items-center sm:p-8">
+                  {/* Spotlight Poster with Skeleton */}
+                  <div className="relative aspect-[2/3] w-24 shrink-0 overflow-hidden rounded-2xl border border-white/10 shadow-2xl sm:w-28">
+                    <PosterImage
+                      src={spotlightGame.coverUrl}
+                      alt={spotlightGame.name}
+                      priority
+                      sizes="120px"
+                    />
+                  </div>
+
+                  {/* Spotlight Info */}
+                  <div className="flex-1 space-y-2">
+                    <div className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/20 bg-amber-400/10 px-2.5 py-0.5 font-bold text-[10.5px] text-amber-300">
+                      <Sparkles className="size-3 text-amber-400" />
+                      <span>Destaque da Comunidade</span>
+                    </div>
+
+                    <h2 className="font-bold text-lg text-white leading-snug tracking-tight sm:text-2xl">
+                      {spotlightGame.name}
+                    </h2>
+
+                    {spotlightGame.summary && (
+                      <p className="line-clamp-2 text-neutral-300 text-xs leading-relaxed">
+                        {spotlightGame.summary}
+                      </p>
+                    )}
+
+                    <div className="flex flex-wrap items-center gap-3 pt-2">
+                      {spotlightGame.rating && (
+                        <div className="flex items-center gap-1 rounded-full border border-white/10 bg-black/60 px-2.5 py-1 font-bold text-amber-300 text-xs">
+                          <Star className="size-3 fill-amber-300 text-amber-300" />
+                          <span>{spotlightGame.rating.toFixed(1)}</span>
+                        </div>
+                      )}
+                      <Link
+                        href={`/games/${spotlightGame.slug}`}
+                        className="inline-flex items-center gap-1.5 rounded-full bg-white px-4 py-1.5 font-semibold text-black text-xs shadow-sm transition-colors hover:bg-neutral-200"
+                      >
+                        <span>Explorar Título</span>
+                        <ChevronRight className="size-3.5" />
+                      </Link>
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+            )}
+
+            {/* "Continue de onde parou" / Jogos Recentes */}
+            {recentPlayedSlugs.length > 0 && (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Play className="size-4 text-emerald-400" />
+                    <h2 className="font-bold text-base text-white sm:text-xl">
+                      Continue de onde parou
+                    </h2>
+                  </div>
+                  <Link
+                    href="/games?tab=descobrir"
+                    className="text-neutral-400 text-xs transition-colors hover:text-white"
+                  >
+                    Ver recomendações
+                  </Link>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+                  {recentPlayedSlugs.map((slug) => (
+                    <Link
+                      key={slug}
+                      href={`/games/${slug}`}
+                      className="group flex items-center gap-2.5 rounded-2xl border border-white/[0.05] bg-neutral-900/60 p-2.5 shadow-sm transition-all hover:border-white/20 hover:bg-neutral-900"
+                    >
+                      <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-neutral-800 text-white transition-transform group-hover:scale-105">
+                        <Gamepad2 className="size-4.5 text-neutral-400 transition-colors group-hover:text-amber-400" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <span className="block truncate font-semibold text-white text-xs capitalize transition-colors group-hover:text-amber-300">
+                          {slug.replace(/-/g, ' ')}
+                        </span>
+                        <span className="mt-0.5 flex items-center gap-1 font-medium text-[10px] text-emerald-400">
+                          <CheckCircle2 className="size-2.5" />
+                          <span>Na sua biblioteca</span>
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Card de Convite para Avaliação */}
+            <div className="space-y-1.5 rounded-2xl border border-white/[0.04] bg-neutral-900/60 p-5 text-center shadow-sm backdrop-blur-sm sm:p-6">
+              <p className="font-medium text-neutral-200 text-sm">
+                Compartilhe sua opinião sobre o que jogou recentemente! 🎮
+              </p>
+              <div>
+                <Link
+                  href="/games"
+                  className="inline-flex items-center gap-1 text-neutral-400 text-xs underline-offset-4 transition-colors hover:text-white hover:underline"
+                >
+                  <span>Explorar os jogos mais aclamados e avaliar</span>
+                  <ChevronRight className="size-3" />
+                </Link>
+              </div>
+            </div>
+
+            {/* Avaliações Populares */}
+            <div className="space-y-4">
+              <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
+                <div className="flex items-center gap-2">
+                  <MessageSquare className="size-4 text-neutral-400" />
+                  <h2 className="font-bold text-base text-white sm:text-xl">
+                    Avaliações populares
+                  </h2>
+                </div>
+
+                {/* Period Filter Tabs */}
+                <div className="flex w-fit items-center gap-1 rounded-full border border-white/[0.04] bg-neutral-900/80 p-1">
+                  {PERIOD_TABS.map((tab) => {
+                    const isActive = selectedPeriod === tab.id;
+                    return (
+                      <button
+                        key={tab.id}
+                        type="button"
+                        onClick={() => setSelectedPeriod(tab.id)}
+                        className={`select-none rounded-full px-3 py-1 text-xs transition-all ${
+                          isActive
+                            ? 'bg-white/[0.12] font-semibold text-white shadow-sm'
+                            : 'text-neutral-400 hover:bg-white/[0.04] hover:text-white'
+                        }`}
+                      >
+                        {tab.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Reviews Feed List */}
+              {filteredReviews.length > 0 ? (
+                <div className="space-y-3">
+                  {filteredReviews.map((review) => (
+                    <div
+                      key={review.id}
+                      className="space-y-3 rounded-2xl border border-white/[0.03] bg-neutral-900/40 p-4 transition-colors hover:bg-neutral-900/60 sm:p-5"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2.5">
+                          <div className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-neutral-800 font-bold text-neutral-300 text-xs">
+                            {review.user?.avatarUrl ? (
+                              <Image
+                                src={review.user.avatarUrl}
+                                alt={review.user.username}
+                                width={32}
+                                height={32}
+                                className="size-full object-cover"
+                              />
+                            ) : (
+                              (review.user?.displayName ||
+                                review.user?.username ||
+                                'U')[0].toUpperCase()
+                            )}
+                          </div>
+                          <div>
+                            <span className="font-semibold text-white text-xs">
+                              {review.user?.displayName || review.user?.username}
+                            </span>
+                            <span className="ml-1.5 text-[11px] text-neutral-400">
+                              @{review.user?.username}
+                            </span>
+                          </div>
+                        </div>
+
+                        {/* Rating Stars Badge */}
+                        <div className="flex items-center gap-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-1">
+                          <Star className="size-3 fill-amber-400 text-amber-400" />
+                          <span className="font-bold text-amber-400 text-xs">
+                            {review.rating.toFixed(1)}
+                          </span>
+                        </div>
+                      </div>
+
+                      {/* Game Context & Review Content */}
+                      <div>
+                        <Link
+                          href={`/games/${review.gameSlug}`}
+                          className="font-semibold text-neutral-300 text-xs transition-colors hover:text-white"
+                        >
+                          {review.gameTitle}
+                        </Link>
+                        {review.reviewText && (
+                          <p className="mt-1 line-clamp-3 text-neutral-300 text-xs leading-relaxed">
+                            {review.reviewText}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Footer: platform & hours */}
+                      {(review.platform || review.hoursPlayed) && (
+                        <div className="flex items-center gap-3 pt-1 text-[11px] text-neutral-400">
+                          {review.platform && <span>{review.platform}</span>}
+                          {review.hoursPlayed && (
+                            <span className="flex items-center gap-1">
+                              <Clock className="size-3" />
+                              {review.hoursPlayed}h jogadas
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                /* Sleek Empty State for Reviews */
+                <div className="space-y-2.5 rounded-2xl border border-white/[0.04] bg-neutral-900/30 p-8 text-center">
+                  <Gamepad2 className="mx-auto size-8 text-neutral-600" />
+                  <p className="text-neutral-400 text-xs">
+                    Ainda não há avaliações comunitárias gravadas neste período.
+                  </p>
+                  <Link
+                    href="/games"
+                    className="inline-flex items-center gap-1.5 pt-1 font-medium text-white text-xs hover:underline"
+                  >
+                    <span>Explorar catálogo para avaliar</span>
+                    <ChevronRight className="size-3.5" />
+                  </Link>
+                </div>
+              )}
+            </div>
+
+            {/* Atividade da sua rede */}
+            <div className="space-y-4 pt-2">
+              <div className="flex items-center gap-2">
+                <TrendingUp className="size-4 text-neutral-400" />
+                <h2 className="font-bold text-base text-white sm:text-xl">Atividade da sua rede</h2>
+              </div>
+
+              {activities.length > 0 ? (
+                <div className="space-y-2.5">
+                  {activities.map((act) => (
+                    <div
+                      key={act.id}
+                      className="flex items-center justify-between gap-3 rounded-xl border border-white/[0.03] bg-neutral-900/40 p-3.5 text-neutral-300 text-xs"
+                    >
+                      <div className="flex items-center gap-2.5">
+                        <div className="flex size-7 items-center justify-center overflow-hidden rounded-full bg-neutral-800 font-bold text-[10px]">
+                          {act.user?.avatarUrl ? (
+                            <Image
+                              src={act.user.avatarUrl}
+                              alt={act.user.username}
+                              width={28}
+                              height={28}
+                              className="size-full object-cover"
+                            />
+                          ) : (
+                            (act.user?.displayName || act.user?.username || 'U')[0].toUpperCase()
+                          )}
+                        </div>
+                        <div>
+                          <span className="font-semibold text-white">
+                            {act.user?.displayName || act.user?.username}
+                          </span>{' '}
+                          <span className="text-neutral-400">
+                            {act.type === 'played'
+                              ? 'jogou'
+                              : act.type === 'reviewed'
+                                ? 'avaliou'
+                                : 'adicionou à lista'}
+                          </span>{' '}
+                          <Link
+                            href={`/games/${act.gameSlug}`}
+                            className="font-medium text-white hover:underline"
+                          >
+                            {act.gameSlug}
+                          </Link>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="space-y-1 rounded-2xl border border-white/[0.04] bg-neutral-900/30 p-6 text-center">
+                  <p className="text-neutral-400 text-xs">
+                    Nenhuma atividade recente encontrada na sua rede.
+                  </p>
+                  <p className="text-[11px] text-neutral-500">
+                    Conecte sua conta Steam ou avalie títulos para compartilhar seu progresso com
+                    outros jogadores.
+                  </p>
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* RIGHT COLUMN: Sidebar (4 cols on lg) */}
+          <aside className="space-y-7 lg:col-span-4">
+            {/* Jogos Populares */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <TrendingUp className="size-4 text-neutral-400" />
+                  <h2 className="font-bold text-sm text-white sm:text-base">Jogos Populares</h2>
+                </div>
+                <Link
+                  href="/games?tab=populares"
+                  className="text-neutral-400 text-xs transition-colors hover:text-white"
+                >
+                  Ver todos
+                </Link>
+              </div>
+
+              {/* Row of 3 poster cards with Skeletons */}
+              <div className="grid grid-cols-3 gap-2 sm:gap-2.5">
+                {popularGames.map((game) => (
+                  <Link
+                    key={game.id || game.slug}
+                    href={`/games/${game.slug}`}
+                    className="group relative block aspect-[2/3] overflow-hidden rounded-xl border border-white/[0.05] bg-neutral-900 shadow-md transition-all hover:scale-[1.02] hover:border-white/20"
+                  >
+                    <PosterImage src={game.coverUrl} alt={game.name} />
+
+                    {/* Dark gradient at bottom */}
+                    <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/90 via-black/20 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100">
+                      <span className="line-clamp-1 font-semibold text-[10px] text-white">
+                        {game.name}
+                      </span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {/* Mais Bem Avaliados */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <Award className="size-4 text-amber-400" />
+                  <h2 className="font-bold text-sm text-white sm:text-base">Mais Bem Avaliados</h2>
+                </div>
+                <Link
+                  href="/games?tab=bem-avaliados"
+                  className="text-neutral-400 text-xs transition-colors hover:text-white"
+                >
+                  Ver todos
+                </Link>
+              </div>
+
+              {/* Row of 3 poster cards with Skeletons */}
+              <div className="grid grid-cols-3 gap-2 sm:gap-2.5">
+                {topRatedGames.map((game) => (
+                  <Link
+                    key={game.id || game.slug}
+                    href={`/games/${game.slug}`}
+                    className="group relative block aspect-[2/3] overflow-hidden rounded-xl border border-white/[0.05] bg-neutral-900 shadow-md transition-all hover:scale-[1.02] hover:border-white/20"
+                  >
+                    <PosterImage src={game.coverUrl} alt={game.name} />
+
+                    {/* Rating badge */}
+                    {game.rating && (
+                      <div className="absolute top-1.5 right-1.5 z-10 flex items-center gap-0.5 rounded-md border border-amber-400/20 bg-black/85 px-1.5 py-0.5 backdrop-blur-sm">
+                        <Star className="size-2.5 fill-amber-400 text-amber-400" />
+                        <span className="font-bold text-[10px] text-white">
+                          {game.rating.toFixed(1)}
+                        </span>
+                      </div>
+                    )}
+
+                    {/* Dark gradient at bottom */}
+                    <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/90 via-black/20 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100">
+                      <span className="line-clamp-1 font-semibold text-[10px] text-white">
+                        {game.name}
+                      </span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {/* Em Breve / Mais Aguardados */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-1.5">
+                  <Flame className="size-4 text-orange-400" />
+                  <h2 className="font-bold text-sm text-white sm:text-base">Mais Aguardados</h2>
+                </div>
+                <Link
+                  href="/games?tab=lancamentos"
+                  className="text-neutral-400 text-xs transition-colors hover:text-white"
+                >
+                  Ver todos
+                </Link>
+              </div>
+
+              {/* Row of 3 poster cards with Skeletons */}
+              <div className="grid grid-cols-3 gap-2 sm:gap-2.5">
+                {upcomingGames.map((game) => (
+                  <Link
+                    key={game.id || game.slug}
+                    href={`/games/${game.slug}`}
+                    className="group relative block aspect-[2/3] overflow-hidden rounded-xl border border-white/[0.05] bg-neutral-900 shadow-md transition-all hover:scale-[1.02] hover:border-white/20"
+                  >
+                    <PosterImage src={game.coverUrl} alt={game.name} />
+
+                    {/* Steam Awaited / Release year badge */}
+                    <div className="absolute top-1.5 right-1.5 z-10 flex items-center gap-1 rounded-md border border-amber-400/20 bg-black/85 px-1.5 py-0.5 backdrop-blur-sm">
+                      <Sparkles className="size-2.5 text-amber-400" />
+                      <span className="font-bold text-[9px] text-amber-300">
+                        {game.isSteamAwaited ? 'Steam' : game.releaseYear || '2025'}
+                      </span>
+                    </div>
+
+                    {/* Dark gradient at bottom */}
+                    <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/90 via-black/20 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100">
+                      <span className="line-clamp-1 font-semibold text-[10px] text-white">
+                        {game.name}
+                      </span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </main>
+
+      {/* Floating Micro-Pill (Bottom Right) */}
+      <div className="fixed right-5 bottom-5 z-40">
+        <Link
+          href="/pro"
+          className="group flex select-none items-center gap-2 rounded-full border border-white/[0.06] bg-neutral-900/90 px-3.5 py-1.5 text-neutral-200 text-xs shadow-2xl backdrop-blur-md transition-all hover:bg-neutral-800 active:scale-95"
+        >
+          <Sparkles className="size-3.5 text-amber-400 transition-transform group-hover:rotate-12" />
+          <span className="font-medium text-[11.5px] sm:text-xs">
+            Ganhe 7 dias grátis do plano PRO
+          </span>
+          <span className="rounded-full bg-gradient-to-r from-amber-500 to-amber-600 px-1.5 py-0.2 font-extrabold text-[9px] text-black uppercase tracking-wider">
+            PRO
+          </span>
+        </Link>
+      </div>
+
+      {/* Global Footer */}
+      <Footer />
+    </div>
+  );
+}

--- a/apps/web/src/components/navigation/top-nav.tsx
+++ b/apps/web/src/components/navigation/top-nav.tsx
@@ -1,0 +1,530 @@
+'use client';
+
+import {
+  Calendar,
+  ChevronDown,
+  Gamepad2,
+  Heart,
+  Home,
+  ListFilter,
+  Loader2,
+  Search,
+  Sparkles,
+  Star,
+  X
+} from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useRef, useState } from 'react';
+
+import { Logos } from '@/components/logos';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+import { type Game, getFeaturedAwaitedGame, searchGames } from '@/lib/games';
+
+const DROPDOWN_OPTIONS = [
+  {
+    tab: 'descobrir',
+    href: '/games?tab=descobrir',
+    title: 'Descobrir',
+    desc: 'Explore uma vasta seleção de jogos com filtros personalizados e opções de ordenação.',
+    icon: Sparkles,
+    activeColor: 'text-white',
+    hoverColor: 'group-hover:text-white'
+  },
+  {
+    tab: 'populares',
+    href: '/games?tab=populares',
+    title: 'Populares',
+    desc: 'Confira os jogos que estão conquistando o público e dominando as listas de favoritos.',
+    icon: Heart,
+    activeColor: 'text-white',
+    hoverColor: 'group-hover:text-white'
+  },
+  {
+    tab: 'bem-avaliados',
+    href: '/games?tab=bem-avaliados',
+    title: 'Bem avaliados',
+    desc: 'Explore os títulos mais aclamados, com as melhores avaliações do público e da crítica.',
+    icon: Star,
+    activeColor: 'text-white',
+    hoverColor: 'group-hover:text-white'
+  },
+  {
+    tab: 'lancamentos',
+    href: '/games?tab=lancamentos',
+    title: 'Lançamentos',
+    desc: 'Confira os lançamentos populares e recentes do Steam em tempo real.',
+    icon: Calendar,
+    activeColor: 'text-white',
+    hoverColor: 'group-hover:text-white'
+  }
+];
+
+function TopNavContent({
+  searchParams
+}: {
+  searchParams?: ReturnType<typeof useSearchParams> | null;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { user: currentUser } = useAuth();
+  const isGamesPage = pathname === '/games';
+  const currentTab = isGamesPage ? searchParams?.get('tab') || 'descobrir' : null;
+
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Game[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Global shortcut CTRL+K / CMD+K
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setSearchOpen((prev) => !prev);
+      } else if (e.key === 'Escape') {
+        setSearchOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // Focus input on search open
+  useEffect(() => {
+    if (searchOpen) {
+      const frame = requestAnimationFrame(() => searchInputRef.current?.focus());
+      return () => cancelAnimationFrame(frame);
+    } else {
+      setSearchQuery('');
+      setSearchResults([]);
+    }
+  }, [searchOpen]);
+
+  // Live search debounce
+  useEffect(() => {
+    if (!searchQuery.trim()) {
+      setSearchResults([]);
+      setIsSearching(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const results = await searchGames(searchQuery.trim(), controller.signal);
+        setSearchResults(results.slice(0, 6));
+      } catch (err) {
+        console.error('Search error:', err);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 220);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [searchQuery]);
+
+  const [gamesMenuOpen, setGamesMenuOpen] = useState(false);
+  const [featuredAwaited, setFeaturedAwaited] = useState<Game | null>(null);
+  const closeTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    getFeaturedAwaitedGame()
+      .then((game) => {
+        if (game) setFeaturedAwaited(game);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleGamesMouseEnter = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    setGamesMenuOpen(true);
+  };
+
+  const handleGamesMouseLeave = () => {
+    closeTimerRef.current = setTimeout(() => {
+      setGamesMenuOpen(false);
+    }, 280);
+  };
+
+  // Close menus on path change
+  useEffect(() => {
+    setGamesMenuOpen(false);
+    setSearchOpen(false);
+  }, []);
+
+  const NAV_ITEMS = [
+    { href: '/home', label: 'Início', icon: Home, exact: true },
+    { href: '/games', label: 'Jogos', icon: Gamepad2, exact: false, hasDropdown: true },
+    { href: '/lists', label: 'Listas', icon: ListFilter, exact: false }
+  ];
+
+  return (
+    <>
+      {/* Centralized Floating Capsule Bar */}
+      <div className="pointer-events-none fixed inset-x-0 top-3 z-50 flex flex-col items-center px-3 sm:top-4 sm:px-4">
+        <header className="pointer-events-auto relative flex h-11 w-[calc(100vw-1rem)] min-w-0 max-w-2xl items-center justify-between gap-2 rounded-full bg-neutral-900/90 px-2.5 shadow-[0_16px_40px_rgba(0,0,0,0.85)] backdrop-blur-xl transition-all sm:h-12 sm:min-w-[720px] sm:gap-9 sm:px-3.5">
+          {/* Left: Logo & Nav Links */}
+          <div className="flex items-center gap-1 sm:gap-2">
+            <Link
+              href="/home"
+              className="flex size-8 items-center justify-center rounded-full bg-white/[0.04] p-1.5 transition-colors hover:bg-white/[0.08] active:scale-95"
+            >
+              <Logos.Joysticked className="size-full text-white" />
+            </Link>
+
+            <nav className="flex items-center gap-0.5 font-medium text-xs sm:gap-1">
+              {NAV_ITEMS.map((item) => {
+                const isActive = item.exact
+                  ? pathname === item.href || (item.href === '/' && pathname === '/home')
+                  : pathname.startsWith(item.href);
+                const Icon = item.icon;
+
+                if (item.hasDropdown) {
+                  return (
+                    // biome-ignore lint/a11y/noStaticElementInteractions: Dropdown hover container
+                    <div
+                      key={item.href}
+                      onMouseEnter={handleGamesMouseEnter}
+                      onMouseLeave={handleGamesMouseLeave}
+                      className="relative"
+                    >
+                      <Link
+                        href={item.href}
+                        onClick={() => setGamesMenuOpen(false)}
+                        className="relative flex select-none items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[11.5px] text-neutral-300 transition-colors hover:text-white sm:px-3 sm:text-xs"
+                      >
+                        {(isActive || gamesMenuOpen) && (
+                          <motion.div
+                            layoutId="active-top-nav-pill"
+                            transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+                            className="absolute inset-0 rounded-full border border-white/15 bg-white/[0.12] shadow-[0_2px_12px_rgba(255,255,255,0.08)]"
+                          />
+                        )}
+                        <span className="relative z-10 flex items-center gap-1.5">
+                          <Icon className="size-3.5" />
+                          <span>{item.label}</span>
+                          <ChevronDown
+                            className={`size-3 opacity-70 transition-transform duration-200 ${
+                              gamesMenuOpen ? 'rotate-180 text-white opacity-100' : ''
+                            }`}
+                          />
+                        </span>
+                      </Link>
+                    </div>
+                  );
+                }
+
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className="relative flex select-none items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[11.5px] text-neutral-300 transition-colors hover:text-white sm:px-3 sm:text-xs"
+                  >
+                    {isActive && (
+                      <motion.div
+                        layoutId="active-top-nav-pill"
+                        transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+                        className="absolute inset-0 rounded-full border border-white/15 bg-white/[0.12] shadow-[0_2px_12px_rgba(255,255,255,0.08)]"
+                      />
+                    )}
+                    <span className="relative z-10 flex items-center gap-1.5">
+                      <Icon className="size-3.5" />
+                      <span>{item.label}</span>
+                    </span>
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+
+          {/* Right: Search Pill & User Profile */}
+          <div className="flex items-center gap-2">
+            {/* Search Pill with CTRL+K */}
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              className="flex cursor-pointer select-none items-center gap-2 rounded-full bg-white/[0.04] px-2.5 py-1 text-neutral-400 text-xs transition-colors hover:bg-white/[0.08] hover:text-neutral-200 sm:px-3"
+            >
+              <Search className="size-3.5 text-neutral-400" />
+              <span className="hidden text-[11px] md:inline">Procure por tudo</span>
+              <kbd className="hidden items-center rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[9px] text-neutral-400 sm:inline-flex">
+                CTRL + K
+              </kbd>
+            </button>
+
+            {/* User Avatar Circle */}
+            {currentUser ? (
+              <Link
+                href={`/${currentUser.username}`}
+                title={`@${currentUser.username}`}
+                className="flex size-7 items-center justify-center overflow-hidden rounded-full bg-neutral-800 transition-all hover:ring-2 hover:ring-white/20 active:scale-95 sm:size-8"
+              >
+                {currentUser.avatarUrl ? (
+                  <Image
+                    src={currentUser.avatarUrl}
+                    alt={currentUser.username}
+                    width={32}
+                    height={32}
+                    className="size-full object-cover"
+                  />
+                ) : (
+                  <div className="flex size-full items-center justify-center bg-indigo-900 font-bold text-[10px] text-white uppercase">
+                    {currentUser.username[0] || 'U'}
+                  </div>
+                )}
+              </Link>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                asChild
+                className="h-7 rounded-full bg-white/[0.05] px-3 text-white text-xs hover:bg-white/[0.1]"
+              >
+                <Link href="/auth">Entrar</Link>
+              </Button>
+            )}
+          </div>
+        </header>
+
+        {/* Mega Menu Flyout Dropdown for "Jogos" with Rich Spring Animations */}
+        <AnimatePresence>
+          {gamesMenuOpen && (
+            <motion.div
+              initial={{ opacity: 0, y: -10, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -8, scale: 0.97 }}
+              transition={{ type: 'spring', stiffness: 420, damping: 28 }}
+              onMouseEnter={handleGamesMouseEnter}
+              onMouseLeave={handleGamesMouseLeave}
+              className="pointer-events-auto mt-2.5 flex w-[640px] max-w-[94vw] select-none flex-col gap-3 rounded-3xl border border-[#303030] bg-[#121212]/[0.98] p-4 shadow-[0_24px_70px_rgba(0,0,0,0.9)] backdrop-blur-2xl"
+            >
+              {/* Compact featured game */}
+              <motion.div
+                whileHover={{ y: -1 }}
+                transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+                className="w-full"
+              >
+                <Link
+                  href={`/games/${featuredAwaited?.slug || 'halloween-the-game'}`}
+                  onClick={() => setGamesMenuOpen(false)}
+                  className="group flex items-center gap-4 rounded-2xl border border-[#303030] bg-[#0A0A0A] p-2.5 transition-colors hover:border-white/30"
+                >
+                  <div className="size-14 shrink-0 overflow-hidden rounded-xl bg-[#303030]">
+                    <Image
+                      src={
+                        featuredAwaited?.coverUrl ||
+                        'https://images.igdb.com/igdb/image/upload/t_cover_big/coc6x4.webp'
+                      }
+                      alt={featuredAwaited?.name || 'Halloween: The Game'}
+                      fill
+                      sizes="56px"
+                      className="size-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <span className="block text-[10px] text-neutral-500 uppercase tracking-wider">
+                      Em destaque
+                    </span>
+                    <span className="mt-0.5 block truncate font-bold text-sm text-white transition-colors group-hover:text-neutral-300">
+                      {featuredAwaited?.name || 'Halloween: The Game'}
+                    </span>
+                    <span className="mt-1 block truncate text-[11px] text-neutral-500">
+                      {featuredAwaited?.platforms?.[0] || 'PC (Steam)'} &bull; Em breve
+                    </span>
+                  </div>
+                  <ChevronDown className="-rotate-90 size-4 shrink-0 text-neutral-500 transition-transform group-hover:translate-x-0.5 group-hover:text-white" />
+                </Link>
+              </motion.div>
+
+              {/* Short category links */}
+              <div className="grid grid-cols-2 gap-2">
+                {DROPDOWN_OPTIONS.map((item) => {
+                  const isTabActive = currentTab === item.tab;
+                  const Icon = item.icon;
+                  return (
+                    <motion.div
+                      key={item.tab}
+                      whileHover={{ scale: 1.025, x: 2 }}
+                      whileTap={{ scale: 0.98 }}
+                      transition={{ type: 'spring', stiffness: 450, damping: 25 }}
+                    >
+                      <Link
+                        href={item.href}
+                        onClick={() => setGamesMenuOpen(false)}
+                        className={`group flex h-full flex-col gap-1.5 rounded-2xl border p-3.5 text-left transition-all ${
+                          isTabActive
+                            ? 'border-white/25 bg-white/[0.1] text-white shadow-md ring-1 ring-white/10'
+                            : 'border-[#303030] bg-[#0A0A0A]/50 text-neutral-300 hover:border-white/20 hover:bg-white/[0.05]'
+                        }`}
+                      >
+                        <div
+                          className={`flex items-center gap-1.5 font-bold text-xs transition-colors ${
+                            isTabActive ? item.activeColor : `text-white ${item.hoverColor}`
+                          }`}
+                        >
+                          <Icon
+                            className={`size-3.5 ${
+                              isTabActive
+                                ? item.activeColor
+                                : 'text-neutral-400 group-hover:text-white'
+                            }`}
+                          />
+                          <span>{item.title}</span>
+                        </div>
+                        <p className="text-[11px] text-neutral-500 leading-relaxed transition-colors group-hover:text-neutral-300">
+                          {item.desc}
+                        </p>
+                      </Link>
+                    </motion.div>
+                  );
+                })}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Quick Search Modal (CTRL + K) */}
+      <AnimatePresence>
+        {searchOpen && (
+          <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/75 px-4 pt-20 backdrop-blur-md sm:pt-28">
+            <motion.div
+              initial={{ opacity: 0, scale: 0.96, y: -8 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.96, y: -8 }}
+              transition={{ duration: 0.15 }}
+              className="relative w-full max-w-xl space-y-3 rounded-2xl bg-neutral-900/95 p-4 shadow-2xl"
+            >
+              {/* Search Bar Input */}
+              <div className="relative flex items-center">
+                <Search className="absolute left-3.5 size-4 text-neutral-400" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Procure por jogos, franquias, gêneros..."
+                  className="w-full rounded-xl bg-white/[0.05] py-2.5 pr-10 pl-10 text-sm text-white placeholder-neutral-500 focus:outline-none focus:ring-1 focus:ring-white/20"
+                />
+                {searchQuery ? (
+                  <button
+                    type="button"
+                    onClick={() => setSearchQuery('')}
+                    className="absolute right-3 text-neutral-400 hover:text-white"
+                  >
+                    <X className="size-4" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setSearchOpen(false)}
+                    className="absolute right-3 rounded bg-white/[0.08] px-1.5 py-0.5 font-mono text-[10px] text-neutral-400 hover:text-white"
+                  >
+                    ESC
+                  </button>
+                )}
+              </div>
+
+              {/* Live Search Results */}
+              <div className="max-h-[380px] space-y-1 overflow-y-auto">
+                {isSearching ? (
+                  <div className="flex items-center justify-center gap-2 p-8 text-center text-neutral-400 text-xs">
+                    <Loader2 className="size-4 animate-spin" />
+                    <span>Buscando jogos...</span>
+                  </div>
+                ) : searchResults.length > 0 ? (
+                  searchResults.map((game) => (
+                    <button
+                      key={game.id || game.slug}
+                      type="button"
+                      onClick={() => {
+                        setSearchOpen(false);
+                        router.push(`/games/${game.slug}`);
+                      }}
+                      className="group flex w-full items-center gap-3 rounded-xl p-2 text-left transition-colors hover:bg-white/[0.06]"
+                    >
+                      <div className="relative aspect-[3/4] w-9 shrink-0 overflow-hidden rounded-md bg-neutral-800">
+                        {game.coverUrl ? (
+                          <Image
+                            src={game.coverUrl}
+                            alt={game.name}
+                            fill
+                            sizes="36px"
+                            className="object-cover"
+                          />
+                        ) : (
+                          <div className="flex size-full items-center justify-center bg-neutral-800 text-neutral-600">
+                            <Gamepad2 className="size-3.5" />
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <p className="truncate font-semibold text-white text-xs transition-colors group-hover:text-purple-300">
+                            {game.name}
+                          </p>
+                          {game.releaseYear && (
+                            <span className="shrink-0 text-[10px] text-neutral-400">
+                              ({game.releaseYear})
+                            </span>
+                          )}
+                        </div>
+                        {game.genres && game.genres.length > 0 && (
+                          <p className="truncate text-[10px] text-neutral-400">
+                            {game.genres.slice(0, 2).join(' • ')}
+                          </p>
+                        )}
+                      </div>
+
+                      {game.rating && (
+                        <div className="flex shrink-0 items-center gap-1 font-bold text-[10px] text-amber-300">
+                          <Star className="size-2.5 fill-amber-300" />
+                          <span>{Number(game.rating).toFixed(1)}</span>
+                        </div>
+                      )}
+                    </button>
+                  ))
+                ) : searchQuery.trim() ? (
+                  <div className="p-8 text-center text-neutral-400 text-xs">
+                    Nenhum jogo encontrado para &ldquo;{searchQuery}&rdquo;.
+                  </div>
+                ) : (
+                  <div className="p-6 text-center text-neutral-500 text-xs">
+                    Digite o nome de um jogo para buscar rapidamente.
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+function TopNavWithParams() {
+  const searchParams = useSearchParams();
+  return <TopNavContent searchParams={searchParams} />;
+}
+
+export function TopNav() {
+  return (
+    <Suspense fallback={<TopNavContent searchParams={null} />}>
+      <TopNavWithParams />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/games.ts
+++ b/apps/web/src/lib/games.ts
@@ -1,0 +1,268 @@
+import { cache } from 'react';
+import { env } from '@/env';
+
+export interface Game {
+  id: number | string;
+  name: string;
+  slug: string;
+  summary?: string | null;
+  storyline?: string | null;
+  coverUrl?: string | null;
+  bannerUrl?: string | null;
+  artworks?: string[];
+  screenshots?: string[];
+  genres?: string[];
+  platforms?: string[];
+  gameModes?: string[];
+  firstReleaseDate?: string | null;
+  releaseYear?: string | null;
+  developer?: string | null;
+  publisher?: string | null;
+  rating?: number | null;
+  aggregatedRating?: number | null;
+  ratingCount?: number | null;
+  totalRating?: number | null;
+  similarGames?: Game[];
+  recommendedGames?: Game[];
+  isSteamAwaited?: boolean;
+  isSteamTopSeller?: boolean;
+  isSteamNewRelease?: boolean;
+}
+
+export interface ReviewUser {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface GameReview {
+  id: string;
+  gameId: string;
+  gameSlug: string;
+  gameTitle: string;
+  userId: string;
+  user: ReviewUser;
+  rating: number;
+  reviewText: string | null;
+  containsSpoiler?: boolean;
+  platform: string | null;
+  hoursPlayed: string | null;
+  likesCount: number;
+  createdAt: string;
+}
+
+export interface GameActivity {
+  id: string;
+  gameId: string;
+  gameSlug: string;
+  gameTitle: string;
+  userId: string;
+  user: ReviewUser;
+  type: string;
+  detail: string | null;
+  platform: string | null;
+  createdAt: string;
+}
+
+export interface GameDetailsResponse {
+  game: Game;
+  reviews: GameReview[];
+  activities: GameActivity[];
+  similarGames?: Game[];
+  recommendedGames?: Game[];
+}
+
+export async function searchGames(query: string, signal?: AbortSignal): Promise<Game[]> {
+  if (!query.trim()) return [];
+  try {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/games?q=${encodeURIComponent(query)}`, {
+      cache: 'no-store',
+      signal
+    });
+    if (!res.ok) throw new Error('Falha ao buscar jogos');
+    const data = await res.json();
+    return data.games || [];
+  } catch (err) {
+    console.error('searchGames error:', err);
+    return [];
+  }
+}
+
+export interface DiscoverResponse {
+  games: Game[];
+  basedOn: string[];
+  hasMore: boolean;
+}
+
+export async function getDiscoverGames({
+  played = [],
+  offset = 0,
+  limit = 21,
+  userId
+}: {
+  played?: string[];
+  offset?: number;
+  limit?: number;
+  userId?: string;
+} = {}): Promise<DiscoverResponse> {
+  try {
+    const params = new URLSearchParams();
+    params.set('limit', String(limit));
+    params.set('offset', String(offset));
+    if (played.length > 0) {
+      params.set('played', played.join(','));
+    }
+    if (userId) {
+      params.set('userId', userId);
+    }
+
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/games/discover?${params.toString()}`, {
+      cache: 'no-store'
+    });
+    if (!res.ok) throw new Error('Falha ao buscar recomendações personalizadas');
+    const data = await res.json();
+    return {
+      games: data.games || [],
+      basedOn: data.basedOn || [],
+      hasMore: data.hasMore ?? false
+    };
+  } catch (err) {
+    console.error('getDiscoverGames error:', err);
+    return { games: [], basedOn: [], hasMore: false };
+  }
+}
+
+async function fetchApi<T>(path: string, init: RequestInit | undefined, fallback: T): Promise<T> {
+  try {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}${path}`, init);
+    if (!res.ok) return fallback;
+    return await res.json();
+  } catch (err) {
+    console.error(`fetchApi error on ${path}:`, err);
+    return fallback;
+  }
+}
+
+export async function getPopularGames(limit = 18, offset = 0): Promise<Game[]> {
+  const data = await fetchApi<{ games?: Game[] }>(
+    `/games/popular?limit=${limit}&offset=${offset}`,
+    { next: { revalidate: 3600 } },
+    { games: [] }
+  );
+  return data.games || [];
+}
+
+export async function getTopRatedGames(limit = 18, offset = 0): Promise<Game[]> {
+  const data = await fetchApi<{ games?: Game[] }>(
+    `/games/top-rated?limit=${limit}&offset=${offset}`,
+    { next: { revalidate: 3600 } },
+    { games: [] }
+  );
+  return data.games || [];
+}
+
+export async function getUpcomingGames(limit = 18): Promise<Game[]> {
+  const data = await fetchApi<{ games?: Game[] }>(
+    `/games/upcoming?limit=${limit}`,
+    { next: { revalidate: 3600 } },
+    { games: [] }
+  );
+  return data.games || [];
+}
+
+export async function getFeaturedAwaitedGame(): Promise<Game | null> {
+  const data = await fetchApi<{ game?: Game }>(
+    '/games/featured-awaited',
+    { next: { revalidate: 3600 } },
+    {}
+  );
+  return data.game || null;
+}
+
+export async function getTopSellers(limit = 18): Promise<Game[]> {
+  const data = await fetchApi<{ games?: Game[] }>(
+    `/games/top-sellers?limit=${limit}`,
+    { next: { revalidate: 3600 } },
+    { games: [] }
+  );
+  return data.games || [];
+}
+
+export async function getPopularNewReleases(limit = 18, offset = 0): Promise<Game[]> {
+  const data = await fetchApi<{ games?: Game[] }>(
+    `/games/popular-new-releases?limit=${limit}&offset=${offset}`,
+    { next: { revalidate: 1800 } },
+    { games: [] }
+  );
+  return data.games || [];
+}
+
+export const getGameDetails = cache(async (slug: string): Promise<GameDetailsResponse | null> => {
+  try {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/games/${encodeURIComponent(slug)}`, {
+      next: { revalidate: 300 }
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error('getGameDetails error:', err);
+    return null;
+  }
+});
+
+export async function submitGameReview(
+  slug: string,
+  data: {
+    gameId: string | number;
+    gameTitle: string;
+    rating: number;
+    reviewText?: string;
+    containsSpoiler?: boolean;
+    platform?: string;
+    hoursPlayed?: string;
+  }
+) {
+  const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/games/${encodeURIComponent(slug)}/reviews`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(data)
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}));
+    throw new Error(errorData.message || 'Erro ao enviar avaliação');
+  }
+
+  return await res.json();
+}
+
+export interface HomeFeedData {
+  popularGames: Game[];
+  topRatedGames: Game[];
+  upcomingGames?: Game[];
+  popularReviews: GameReview[];
+  activities: GameActivity[];
+}
+
+export async function getHomeFeed(): Promise<HomeFeedData> {
+  try {
+    const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/home`, {
+      next: { revalidate: 60 }
+    });
+    if (res.ok) {
+      return await res.json();
+    }
+  } catch (err) {
+    console.error('getHomeFeed failed:', err);
+  }
+
+  return {
+    popularGames: [],
+    topRatedGames: [],
+    upcomingGames: [],
+    popularReviews: [],
+    activities: []
+  };
+}


### PR DESCRIPTION
Uses bounded 18-game pages for discovery and infinite scrolling to reduce the initial payload on top of cleanup-and-homepage. Biome passes on the changed files.