### PR TITLE
feat(a11y): migrate modal interactions

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="pt-BR">
       <head>
         <script defer src="https://assets.onedollarstats.com/stonks.js" />
       </head>

--- a/apps/web/src/components/game/game-review-modal.tsx
+++ b/apps/web/src/components/game/game-review-modal.tsx
@@ -15,11 +15,12 @@ import {
   Trash2,
   X
 } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
+import { motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { PixelHeart } from '@/components/landing/pixel-heart';
+import { Dialog } from '@/components/ui/dialog';
 import { useAuth } from '@/hooks/use-auth';
 import { deleteGameReview, type Game, type GameReview, submitGameReview } from '@/lib/games';
 
@@ -398,27 +399,19 @@ export function GameReviewModal({
   };
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-2.5 sm:p-4">
-          {/* Backdrop Blur Overlay */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.15 }}
-            onClick={onClose}
-            className="fixed inset-0 bg-black/85 backdrop-blur-md"
-          />
-
-          {/* Modal Card - 3DS Handheld Dual-Screen Console */}
-          <motion.div
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      title={isEditing ? `Editar avaliação de ${game.name}` : `Avaliar ${game.name}`}
+      description="Defina uma nota, adicione detalhes e publique sua resenha."
+    >
+      <motion.div
             initial={{ opacity: 0, scale: 0.95, y: 16 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 12 }}
             transition={{ type: 'spring', stiffness: 420, damping: 28 }}
             className="scrollbar-none relative z-10 max-h-[92vh] w-full max-w-lg overflow-hidden overflow-y-auto rounded-[32px] border-2 border-white/15 bg-[#0C0C0C] p-3 shadow-[0_30px_90px_rgba(0,0,0,0.95),0_0_50px_rgba(239,68,68,0.12)] sm:p-4.5"
-          >
+      >
             {/* Top Console Shoulder Bar: [L] Bumper, Power LED & [R] Close Bumper */}
             <div className="relative mb-2.5 flex select-none items-center justify-between px-1">
               {/* [ L ] Bumper */}
@@ -446,6 +439,7 @@ export function GameReviewModal({
                     type="button"
                     onClick={handleDelete}
                     title="Excluir Avaliação"
+                    aria-label="Excluir avaliação"
                     className="cursor-pointer rounded-lg border border-red-500/20 bg-red-500/10 px-2 py-1 text-red-400 text-xs transition-colors hover:bg-red-500/20"
                   >
                     <Trash2 className="size-3.5" />
@@ -566,6 +560,7 @@ export function GameReviewModal({
                             <button
                               type="button"
                               onClick={() => handleRemoveTag(tag)}
+                              aria-label={`Remover tag ${tag}`}
                               className="cursor-pointer text-red-400 transition-colors hover:text-white"
                             >
                               <X className="size-3" />
@@ -689,9 +684,7 @@ export function GameReviewModal({
                 </div>
               </div>
             </form>
-          </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+      </motion.div>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/game/game-review-modal.tsx
+++ b/apps/web/src/components/game/game-review-modal.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { PixelHeart } from '@/components/landing/pixel-heart';
 import { Dialog } from '@/components/ui/dialog';
@@ -170,6 +170,7 @@ export function GameReviewModal({
   onReviewCreated,
   onReviewDeleted
 }: GameReviewModalProps) {
+  const handleOpenChange = useCallback((open: boolean) => { if (!open) onClose(); }, [onClose]);
   const router = useRouter();
   const { user: currentUser } = useAuth();
   const [rating, setRating] = useState<number>(initialReview?.rating || 5);
@@ -401,7 +402,7 @@ export function GameReviewModal({
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
+      onOpenChange={handleOpenChange}
       title={isEditing ? `Editar avaliação de ${game.name}` : `Avaliar ${game.name}`}
       description="Defina uma nota, adicione detalhes e publique sua resenha."
     >

--- a/apps/web/src/components/lists/add-game-to-list-modal.tsx
+++ b/apps/web/src/components/lists/add-game-to-list-modal.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { Check, Loader2, Plus, Search, X } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
+import { motion } from 'motion/react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { Dialog } from '@/components/ui/dialog';
 import { type Game, searchGames } from '@/lib/games';
 
 interface AddGameToListModalProps {
@@ -50,27 +51,19 @@ export function AddGameToListModal({
   }, [query]);
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          {/* Backdrop */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="fixed inset-0 bg-black/80 backdrop-blur-md"
-            aria-hidden="true"
-          />
-
-          {/* Modal */}
-          <motion.div
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      title="Adicionar jogos à lista"
+      description="Busque títulos no catálogo para incluir nesta coleção."
+    >
+      <motion.div
             initial={{ opacity: 0, scale: 0.96, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 10 }}
             transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
             className="relative z-10 w-full max-w-xl overflow-hidden rounded-3xl border border-white/10 bg-[#0f0f12] p-5 shadow-[0_24px_70px_rgba(0,0,0,0.95)]"
-          >
+      >
             {/* Header */}
             <div className="flex items-center justify-between pb-3">
               <div>
@@ -84,6 +77,7 @@ export function AddGameToListModal({
               <button
                 type="button"
                 onClick={onClose}
+                aria-label="Fechar diálogo"
                 className="flex size-8 items-center justify-center rounded-xl text-neutral-400 transition-colors hover:bg-white/[0.08] hover:text-white"
               >
                 <X className="size-4" />
@@ -97,6 +91,7 @@ export function AddGameToListModal({
                 type="text"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
+                aria-label="Buscar jogo no catálogo"
                 placeholder="Digite o nome do jogo (ex: Elden Ring, Hollow Knight)..."
                 className="h-10 w-full rounded-2xl border border-white/[0.08] bg-white/[0.03] pr-9 pl-10 text-white text-xs outline-none transition-all placeholder:text-neutral-500 hover:border-white/15 focus:border-white/25 focus:bg-white/[0.06]"
               />
@@ -104,6 +99,7 @@ export function AddGameToListModal({
                 <button
                   type="button"
                   onClick={() => setQuery('')}
+                  aria-label="Limpar busca"
                   className="-translate-y-1/2 absolute top-1/2 right-3 text-neutral-500 hover:text-white"
                 >
                   <X className="size-3.5" />
@@ -186,9 +182,7 @@ export function AddGameToListModal({
                 </div>
               )}
             </div>
-          </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+      </motion.div>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/lists/add-game-to-list-modal.tsx
+++ b/apps/web/src/components/lists/add-game-to-list-modal.tsx
@@ -3,7 +3,7 @@
 import { Check, Loader2, Plus, Search, X } from 'lucide-react';
 import { motion } from 'motion/react';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Dialog } from '@/components/ui/dialog';
 import { type Game, searchGames } from '@/lib/games';
 
@@ -20,6 +20,7 @@ export function AddGameToListModal({
   existingGames,
   onAddGame
 }: AddGameToListModalProps) {
+  const handleOpenChange = useCallback((open: boolean) => { if (!open) onClose(); }, [onClose]);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Game[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -53,7 +54,7 @@ export function AddGameToListModal({
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
+      onOpenChange={handleOpenChange}
       title="Adicionar jogos à lista"
       description="Busque títulos no catálogo para incluir nesta coleção."
     >

--- a/apps/web/src/components/lists/create-list-modal.tsx
+++ b/apps/web/src/components/lists/create-list-modal.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { ListPlus, Sparkles, X } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
+import { motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { Dialog } from '@/components/ui/dialog';
 import { useAuth } from '@/hooks/use-auth';
 import { createCustomList } from '@/lib/lists';
 
@@ -80,27 +81,19 @@ export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalP
   };
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          {/* Backdrop */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="fixed inset-0 bg-black/80 backdrop-blur-md"
-            aria-hidden="true"
-          />
-
-          {/* Dialog Container */}
-          <motion.div
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      title="Criar nova lista"
+      description="Colecione, organize e compartilhe seus jogos favoritos."
+    >
+      <motion.div
             initial={{ opacity: 0, scale: 0.96, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 10 }}
             transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
             className="relative z-10 w-full max-w-lg overflow-hidden rounded-3xl border border-white/10 bg-[#0f0f12] p-6 shadow-[0_24px_70px_rgba(0,0,0,0.95)]"
-          >
+      >
             {/* Header */}
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-3">
@@ -119,6 +112,7 @@ export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalP
               <button
                 type="button"
                 onClick={onClose}
+                aria-label="Fechar diálogo"
                 className="flex size-8 items-center justify-center rounded-xl text-neutral-400 transition-colors hover:bg-white/[0.08] hover:text-white"
               >
                 <X className="size-4" />
@@ -180,6 +174,7 @@ export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalP
                         key={tag}
                         type="button"
                         onClick={() => toggleTag(tag)}
+                        aria-pressed={isSelected}
                         className={`rounded-full px-2.5 py-1 font-medium text-[11px] transition-all ${
                           isSelected
                             ? 'bg-white font-semibold text-black shadow-sm'
@@ -204,6 +199,9 @@ export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalP
                 <button
                   type="button"
                   onClick={() => setIsPublic(!isPublic)}
+                  role="switch"
+                  aria-checked={isPublic}
+                  aria-label="Lista pública"
                   className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
                     isPublic ? 'bg-white' : 'bg-neutral-800'
                   }`}
@@ -235,9 +233,7 @@ export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalP
                 </button>
               </div>
             </form>
-          </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+      </motion.div>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/lists/create-list-modal.tsx
+++ b/apps/web/src/components/lists/create-list-modal.tsx
@@ -3,7 +3,7 @@
 import { ListPlus, Sparkles, X } from 'lucide-react';
 import { motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Dialog } from '@/components/ui/dialog';
 import { useAuth } from '@/hooks/use-auth';
 import { createCustomList } from '@/lib/lists';
@@ -26,6 +26,7 @@ const PRESET_TAGS = [
 ];
 
 export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalProps) {
+  const handleOpenChange = useCallback((open: boolean) => { if (!open) onClose(); }, [onClose]);
   const router = useRouter();
   const { user } = useAuth();
   const [name, setName] = useState('');
@@ -83,7 +84,7 @@ export function CreateListModal({ isOpen, onClose, onSuccess }: CreateListModalP
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
+      onOpenChange={handleOpenChange}
       title="Criar nova lista"
       description="Colecione, organize e compartilhe seus jogos favoritos."
     >

--- a/apps/web/src/components/lists/edit-list-modal.tsx
+++ b/apps/web/src/components/lists/edit-list-modal.tsx
@@ -2,7 +2,7 @@
 
 import { Edit3, X } from 'lucide-react';
 import { motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Dialog } from '@/components/ui/dialog';
 import { type UserList, updateUserList } from '@/lib/lists';
 
@@ -25,6 +25,7 @@ const PRESET_TAGS = [
 ];
 
 export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModalProps) {
+  const handleOpenChange = useCallback((open: boolean) => { if (!open) onClose(); }, [onClose]);
   const [name, setName] = useState(list.name);
   const [description, setDescription] = useState(list.description || '');
   const [isPublic, setIsPublic] = useState(list.isPublic ?? true);
@@ -83,7 +84,7 @@ export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModal
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(open) => !open && onClose()}
+      onOpenChange={handleOpenChange}
       title="Editar lista"
       description="Atualize o título, a descrição, as tags e a privacidade da lista."
     >

--- a/apps/web/src/components/lists/edit-list-modal.tsx
+++ b/apps/web/src/components/lists/edit-list-modal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Edit3, X } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
+import { motion } from 'motion/react';
 import { useEffect, useState } from 'react';
+import { Dialog } from '@/components/ui/dialog';
 import { type UserList, updateUserList } from '@/lib/lists';
 
 interface EditListModalProps {
@@ -80,27 +81,19 @@ export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModal
   };
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
-          {/* Backdrop */}
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            onClick={onClose}
-            className="fixed inset-0 bg-black/85 backdrop-blur-md"
-            aria-hidden="true"
-          />
-
-          {/* Dialog Container */}
-          <motion.div
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => !open && onClose()}
+      title="Editar lista"
+      description="Atualize o título, a descrição, as tags e a privacidade da lista."
+    >
+      <motion.div
             initial={{ opacity: 0, scale: 0.96, y: 12 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 12 }}
             transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
             className="relative z-10 w-full max-w-lg overflow-hidden rounded-3xl border border-white/10 bg-[#0e0e12] p-6 shadow-[0_24px_70px_rgba(0,0,0,0.95)] sm:p-7"
-          >
+      >
             {/* Header */}
             <div className="flex items-start justify-between">
               <div className="flex items-center gap-3">
@@ -120,6 +113,7 @@ export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModal
               <button
                 type="button"
                 onClick={onClose}
+                aria-label="Fechar diálogo"
                 className="flex size-8 items-center justify-center rounded-xl text-neutral-400 transition-colors hover:bg-white/10 hover:text-white"
               >
                 <X className="size-4" />
@@ -180,6 +174,7 @@ export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModal
                         key={tag}
                         type="button"
                         onClick={() => toggleTag(tag)}
+                        aria-pressed={isSelected}
                         className={`rounded-lg px-2.5 py-1 font-medium text-xs transition-all active:scale-95 ${
                           isSelected
                             ? 'border border-amber-500/40 bg-amber-500/15 text-amber-300 shadow-sm'
@@ -204,6 +199,9 @@ export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModal
                 <button
                   type="button"
                   onClick={() => setIsPublic(!isPublic)}
+                  role="switch"
+                  aria-checked={isPublic}
+                  aria-label="Lista pública"
                   className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ${
                     isPublic ? 'bg-amber-400' : 'bg-neutral-700'
                   }`}
@@ -234,9 +232,7 @@ export function EditListModal({ isOpen, list, onClose, onUpdate }: EditListModal
                 </button>
               </div>
             </form>
-          </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
+      </motion.div>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- migrate list and review modals to the shared accessible dialog
- add discernible names and states to close controls, switches, and search fields
- set the document language to Brazilian Portuguese

## Verification
- git diff --check passes
- TypeScript check remains blocked by the existing workspace current-directory runner error