### PR TITLE
fix(web): centralize safe auth navigation

### DIFF
--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect } from 'react';
 import { Logos } from '@/components/logos';
 import { api } from '@/lib/api';
+import { safeReturnPath } from '@/lib/navigation';
 
 function CallbackContent() {
   const router = useRouter();
@@ -15,7 +16,7 @@ function CallbackContent() {
   useEffect(() => {
     const token = searchParams.get('token');
     const userParam = searchParams.get('user');
-    const redirectTarget = searchParams.get('redirect') || '/home';
+    const redirectTarget = safeReturnPath(searchParams.get('redirect'));
 
     if (!token) {
       router.replace('/auth?error=oauth_failed');

--- a/apps/web/src/app/auth/page.tsx
+++ b/apps/web/src/app/auth/page.tsx
@@ -24,12 +24,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { env } from '@/env';
 import { useAuth } from '@/hooks/use-auth';
+import { safeReturnPath } from '@/lib/navigation';
 
 function AuthContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { loginLocal } = useAuth();
-  const redirectTarget = searchParams.get('redirect') || '/home';
+  const redirectTarget = safeReturnPath(searchParams.get('redirect'));
   const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
   const [resendCooldown, setResendCooldown] = useState(0);
   const [isResending, setIsResending] = useState(false);

--- a/apps/web/src/components/game/game-detail-view.tsx
+++ b/apps/web/src/components/game/game-detail-view.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { TopNav } from '@/components/navigation/top-nav';
 import { useAuth } from '@/hooks/use-auth';
 import type { Game, GameActivity, GameReview } from '@/lib/games';
+import { authHref } from '@/lib/navigation';
 import { GameAchievementsTab } from './game-achievements-tab';
 import { GameActivitySection } from './game-activity-section';
 import { GameHero } from './game-hero';
@@ -85,7 +86,7 @@ export function GameDetailView({
   const handleOpenReview = () => {
     if (!currentUser) {
       toast.info('Você precisa entrar ou criar uma conta para avaliar jogos.');
-      router.push(`/auth?redirect=/games/${game.slug}`);
+      router.push(authHref(`/games/${game.slug}`));
       return;
     }
     setEditingReview(userReview || null);
@@ -95,7 +96,7 @@ export function GameDetailView({
   const handleEditReview = (review: GameReview) => {
     if (!currentUser) {
       toast.info('Você precisa entrar ou criar uma conta para avaliar jogos.');
-      router.push(`/auth?redirect=/games/${game.slug}`);
+      router.push(authHref(`/games/${game.slug}`));
       return;
     }
     setEditingReview(review);

--- a/apps/web/src/components/game/game-review-modal.tsx
+++ b/apps/web/src/components/game/game-review-modal.tsx
@@ -22,6 +22,7 @@ import { toast } from 'sonner';
 import { PixelHeart } from '@/components/landing/pixel-heart';
 import { useAuth } from '@/hooks/use-auth';
 import { deleteGameReview, type Game, type GameReview, submitGameReview } from '@/lib/games';
+import { authHref } from '@/lib/navigation';
 
 interface GameReviewModalProps {
   isOpen: boolean;
@@ -187,7 +188,7 @@ export function GameReviewModal({
     if (isOpen && !currentUser) {
       toast.info('Você precisa entrar ou criar uma conta para avaliar jogos.');
       onClose();
-      router.push(`/auth?redirect=/games/${game.slug}`);
+      router.push(authHref(`/games/${game.slug}`));
     }
   }, [isOpen, currentUser, game.slug, router, onClose]);
 
@@ -252,7 +253,7 @@ export function GameReviewModal({
     if (!currentUser) {
       toast.error('Você precisa entrar ou criar uma conta para publicar uma avaliação.');
       onClose();
-      router.push(`/auth?redirect=/games/${game.slug}`);
+      router.push(authHref(`/games/${game.slug}`));
       return;
     }
 

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,11 +1,15 @@
 /** Build an internal auth return URL without allowing arbitrary destinations. */
 export function authHref(returnPath: string): string {
-  const path = returnPath.startsWith('/') && !returnPath.startsWith('//') ? returnPath : '/home';
+  const path = isSafeReturnPath(returnPath) ? returnPath : '/home';
   return `/auth?redirect=${encodeURIComponent(path)}`;
 }
 
 /** Normalize a query-provided return path to a same-origin relative URL. */
 export function safeReturnPath(value: string | null | undefined, fallback = '/home'): string {
-  if (!value || !value.startsWith('/') || value.startsWith('//')) return fallback;
+  if (!value || !isSafeReturnPath(value)) return fallback;
   return value;
+}
+
+function isSafeReturnPath(value: string): boolean {
+  return value.startsWith('/') && !value.startsWith('//') && !value.includes('\\');
 }

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,0 +1,11 @@
+/** Build an internal auth return URL without allowing arbitrary destinations. */
+export function authHref(returnPath: string): string {
+  const path = returnPath.startsWith('/') && !returnPath.startsWith('//') ? returnPath : '/home';
+  return `/auth?redirect=${encodeURIComponent(path)}`;
+}
+
+/** Normalize a query-provided return path to a same-origin relative URL. */
+export function safeReturnPath(value: string | null | undefined, fallback = '/home'): string {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return fallback;
+  return value;
+}


### PR DESCRIPTION
## Summary
- centralize internal auth return URL construction
- reject protocol-relative and non-relative return paths
- remove duplicated auth redirect string construction from game views

## Validation
- `git diff --check`